### PR TITLE
[FD][AOSS-1424] Only allow requests to be created when a matching pos…

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/AuthorisationRequestController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/AuthorisationRequestController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.agentclientauthorisation.controllers
 
+import play.api.Logger
 import play.api.hal.{HalLink, HalLinks, HalResource}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{JsObject, Json}
@@ -23,18 +24,27 @@ import play.api.mvc.Action
 import play.api.mvc.hal.halWriter
 import uk.gov.hmrc.agentclientauthorisation.model.{AgentClientAuthorisationHttpRequest, AgentClientAuthorisationRequest}
 import uk.gov.hmrc.agentclientauthorisation.repository.AuthorisationRequestRepository
+import uk.gov.hmrc.agentclientauthorisation.sa.services.SaLookupService
 import uk.gov.hmrc.domain.AgentCode
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
-import scala.concurrent.Future
-
-class AuthorisationRequestController(authorisationRequestRepository: AuthorisationRequestRepository) extends BaseController {
+class AuthorisationRequestController(authorisationRequestRepository: AuthorisationRequestRepository, saLookupService: SaLookupService)
+  extends BaseController {
 
   def createRequest(agentCode: AgentCode) = Action.async(parse.json) { implicit request =>
-    withJsonBody[AgentClientAuthorisationHttpRequest] { authRequest =>
-      // TODO Audit
-      authorisationRequestRepository.create(agentCode, authRequest.clientSaUtr)
-      Future successful Created //TODO Location header?
+    withJsonBody[AgentClientAuthorisationHttpRequest] { authRequest: AgentClientAuthorisationHttpRequest =>
+      saLookupService.utrAndPostcodeMatch(authRequest.clientSaUtr, authRequest.clientPostcode) map { utrAndPostcodeMatch =>
+        if (utrAndPostcodeMatch) {
+          // TODO Audit
+          //TODO fix race condition, probably with authorisationRequestRepository.create(agentCode, authRequest.clientSaUtr) map { _ => Created }
+          authorisationRequestRepository.create(agentCode, authRequest.clientSaUtr)
+          Created //TODO Location header?
+        } else {
+          // TODO Audit including postcode as well as UTR (don't think we are allowed to log postcode)
+          Logger.warn(s"createRequest not authorised because postcode does not match for UTR ${authRequest.clientSaUtr}")
+          Forbidden("No SA taxpayer found with the given UTR and postcode")
+        }
+      }
     }
   }
 

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/AuthorisationRequestController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/AuthorisationRequestController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.agentclientauthorisation.controllers
 
-import play.api.Logger
 import play.api.hal.{HalLink, HalLinks, HalResource}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{JsObject, Json}
@@ -40,8 +39,7 @@ class AuthorisationRequestController(authorisationRequestRepository: Authorisati
           // TODO Audit
           authorisationRequestRepository.create(agentCode, authRequest.clientSaUtr) map { _ => Created }
         } else {
-          // TODO Audit including postcode as well as UTR (don't think we are allowed to log postcode)
-          Logger.warn(s"createRequest not authorised because postcode does not match for UTR ${authRequest.clientSaUtr}")
+          // TODO Audit failure including UTR and postcode
           Future successful Forbidden("No SA taxpayer found with the given UTR and postcode")
         }
       }

--- a/app/uk/gov/hmrc/agentclientauthorisation/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/microserviceWiring.scala
@@ -67,7 +67,7 @@ trait ControllerRegistry {
   registry: ServiceRegistry =>
 
   private lazy val controllers = Map[Class[_], Controller](
-    classOf[AuthorisationRequestController] -> new AuthorisationRequestController(authorisationRequestRepository),
+    classOf[AuthorisationRequestController] -> new AuthorisationRequestController(authorisationRequestRepository, saLookupService),
     classOf[SaLookupController] -> new SaLookupController(authConnector, saLookupService)
   )
 

--- a/app/uk/gov/hmrc/agentclientauthorisation/model/AgentClientAuthorisationRequest.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/AgentClientAuthorisationRequest.scala
@@ -59,7 +59,7 @@ case class StatusChangeEvent(time: DateTime, status: AuthorisationStatus)
 
 case class AgentClientAuthorisationRequest(id: BSONObjectID, agentCode: AgentCode, clientSaUtr: SaUtr, regime: String = "sa", events: List[StatusChangeEvent])
 
-case class AgentClientAuthorisationHttpRequest(clientSaUtr: SaUtr)
+case class AgentClientAuthorisationHttpRequest(clientSaUtr: SaUtr, clientPostcode: String)
 
 object StatusChangeEvent {
   implicit val statusChangeEventFormat = Json.format[StatusChangeEvent]

--- a/app/uk/gov/hmrc/agentclientauthorisation/sa/services/SaLookupService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/sa/services/SaLookupService.scala
@@ -36,6 +36,9 @@ class SaLookupService(cesaIndividualsConnector: CesaIndividualsConnector) {
     }
   }
 
+  def utrAndPostcodeMatch(saUtr: SaUtr, postcode: String)(implicit hc: HeaderCarrier): Future[Boolean] =
+    lookupByUtrAndPostcode(saUtr, postcode).map(_.isDefined)
+
   def postcodeMatches(postcode: Option[String], toCheck: String) = {
     postcode.flatMap(value => Some(value.toLowerCase.replaceAll(" ", "") == toCheck.toLowerCase.replaceAll(" ", "")))
             .getOrElse(false)

--- a/test/uk/gov/hmrc/agentclientauthorisation/controllers/AuthorisationRequestControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/controllers/AuthorisationRequestControllerSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.controllers
+
+import org.mockito.Matchers.{any, anyString}
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.JsValue
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import uk.gov.hmrc.agentclientauthorisation.model.AgentClientAuthorisationHttpRequest
+import uk.gov.hmrc.agentclientauthorisation.repository.AuthorisationRequestRepository
+import uk.gov.hmrc.agentclientauthorisation.sa.services.SaLookupService
+import uk.gov.hmrc.domain.{AgentCode, SaUtr}
+import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+class AuthorisationRequestControllerSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
+  val repository = mock[AuthorisationRequestRepository]
+  val saLookupService = mock[SaLookupService]
+  val controller = new AuthorisationRequestController(repository, saLookupService)
+
+  implicit val hc = HeaderCarrier()
+
+  val agentCode = AgentCode("123456789012")
+
+  override protected def beforeEach() = {
+    super.beforeEach()
+    reset(repository)
+    reset(saLookupService)
+  }
+
+
+  "createRequest" should {
+    "return a 403 when the UTR and postcode don't match" in {
+      when(saLookupService.utrAndPostcodeMatch(any[SaUtr], anyString)(any[HeaderCarrier])).thenReturn(Future.successful(false))
+
+      val body: JsValue = AgentClientAuthorisationHttpRequest.format.writes(
+        AgentClientAuthorisationHttpRequest(SaUtr("54321"), "BB2 2BB"))
+
+      val result: Result = await(controller.createRequest(agentCode)(FakeRequest().withBody(body)))
+
+      status(result) shouldBe 403
+    }
+  }
+}


### PR DESCRIPTION
…tcode is supplied

This is to prevent the client's name from being revealed (via the getRequests endpoint) to actors who do not know the client's postcode as well as UTR