### PR TITLE
Apb 31 raml

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/microserviceGlobal.scala
@@ -25,6 +25,8 @@ import uk.gov.hmrc.play.http.logging.filters.LoggingFilter
 import uk.gov.hmrc.play.microservice.bootstrap.DefaultMicroserviceGlobal
 import uk.gov.hmrc.play.auth.microservice.filters.AuthorisationFilter
 import net.ceedubs.ficus.Ficus._
+import uk.gov.hmrc.api.config.{ServiceLocatorConfig, ServiceLocatorRegistration}
+import uk.gov.hmrc.play.http.HeaderCarrier
 
 
 object ControllerConfiguration extends ControllerConfig {
@@ -50,7 +52,7 @@ object MicroserviceAuthFilter extends AuthorisationFilter {
   override def controllerNeedsAuth(controllerName: String): Boolean = ControllerConfiguration.paramsForController(controllerName).needsAuth
 }
 
-trait MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with ServiceRegistry with ControllerRegistry {
+trait MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with ServiceRegistry with ControllerRegistry with ServiceLocatorRegistration with ServiceLocatorConfig {
   override val auditConnector = MicroserviceAuditConnector
 
   override def microserviceMetricsConfig(implicit app: Application): Option[Configuration] = app.configuration.getConfig(s"microservice.metrics")
@@ -60,6 +62,8 @@ trait MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with Ser
   override val microserviceAuditFilter = MicroserviceAuditFilter
 
   override val authFilter = Some(MicroserviceAuthFilter)
+
+  override implicit val hc: HeaderCarrier = HeaderCarrier()
 
   override def getControllerInstance[A](controllerClass: Class[A]): A = {
     getController(controllerClass)

--- a/app/uk/gov/hmrc/agentclientauthorisation/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/microserviceWiring.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.agentclientauthorisation.repository.AuthorisationRequestMongo
 import uk.gov.hmrc.agentclientauthorisation.sa.connectors.CesaIndividualsConnector
 import uk.gov.hmrc.agentclientauthorisation.sa.controllers.SaLookupController
 import uk.gov.hmrc.agentclientauthorisation.sa.services.SaLookupService
+import uk.gov.hmrc.api.connector.ServiceLocatorConnector
 import uk.gov.hmrc.api.controllers.DocumentationController
 import uk.gov.hmrc.mongo.MongoConnector
 import uk.gov.hmrc.play.audit.http.HttpAuditing
@@ -65,6 +66,7 @@ trait ServiceRegistry extends ServicesConfig with LazyMongoDbConnection {
   lazy val saLookupService = new SaLookupService(cesaIndividualsConnector)
   lazy val authConnector = new uk.gov.hmrc.agentclientauthorisation.connectors.AuthConnector(new URL(baseUrl("auth")), WSHttp)
   lazy val userDetailsConnector = new UserDetailsConnector(WSHttp)
+  lazy val slConnector = ServiceLocatorConnector(WSHttp)
 }
 
 trait ControllerRegistry {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,6 +59,9 @@ application.global=uk.gov.hmrc.agentclientauthorisation.MicroserviceGlobal
 application.router=prod.Routes
 
 
+# Service Locator Registration.
+appUrl="http://agent-client-authorisation.service"
+
 # Controller
 # ~~~~~
 # By default all controllers will have authorisation, logging and 
@@ -152,6 +155,9 @@ microservice {
     }
 
     services {
+        service-locator {
+            enabled = false
+        }
     }
 }
 
@@ -165,6 +171,10 @@ Dev {
             cesa {
                 host=localhost
                 port=8084
+            }
+            service-locator {
+                host = localhost
+                port = 9602
             }
         }
     }
@@ -180,6 +190,11 @@ Prod {
             cesa {
                 host=hods-proxy
                 port=80
+            }
+            service-locator {
+                host = service-locator.service
+                port = 80
+                enabled = true
             }
         }
     }

--- a/invitations.raml
+++ b/invitations.raml
@@ -28,18 +28,17 @@ types:
       lastUpdated:
         type: datetime
         format: rfc2616
+      arn:
+        description: The MTD platform Agent Reference Number
+        type: string
       regime:
         description: The tax regime for which authorisation is being requested. N.B. this list will expand.
-        type: string
-        enum: [ sa ]
+        type: Regime
       customerRegimeId:
         description: The identifier of the Customer within the regime, e.g. UTR for SA.
         type: string
-      agencyName:
-        description: Name of the Agency requesting authorisation.
-        type: string
-      agentName:
-        description: Name of the Agent requesting authorisation.
+      postcode:
+        description: The customer's postcode.
         type: string
       status:
         type: Status
@@ -47,13 +46,17 @@ types:
       accepted:
           created: "2016-06-27T01:55:28+00.00",
           lastUpdated: "2016-07-02T01:55:28+00.00",
+          arn: "123451234512345",
           regime: "sa",
-          agencyName: "Sally Hughes Accountants",
-          agentName: "Bob McCratchet",
           customerRegimeId: "123456789",
           status: "accepted"
+          postcode: "SW1A 0PW"
+  Regime:
+    description:
+    type: string
+    enum: [ sa, ct ]
 
-/agencies/{mtdArn}/invitations/sent:
+/agencies/{arn}/invitations/sent:
     get:
       description: Get the list of invitations for this agency.
       queryParameters:
@@ -63,16 +66,15 @@ types:
         customerRegimeId:
           type: string
         regime:
-          type: string
-          enum: [ sa ]
+          type: Regime
       responses:
         200:
           description: A list of invitations.
           body: Invitation[]
-        204:
-          description: No invitations matched the search criteria.
         401:
           description: The caller must be authenticated and authorised (logged-in) to use this resource
+        403:
+          description: The caller is not permitted to see this list of invitations.
     post:
       description: Create a new invitation.
       body:
@@ -81,7 +83,8 @@ types:
           newInvitation: |
             {
               "regime" : "sa",
-              "customerRegimeId" : "123456789"
+              "customerRegimeId" : "123456789",
+              "postcode": "SW1AA 0PW"
             }
       responses:
         201:
@@ -96,8 +99,9 @@ types:
             The request will not be fulfilled. Reasons for this may include
                * The agency does not have the requisite active enrolments
                * The customer is not registered for that tax regime
+               * The supplied postcode is not the customer's
       uriParameters:
-        mtdArn:
+        arn:
           description: The MTD platform Agent Reference Number
           type: string
     /{invitationId}:
@@ -108,6 +112,8 @@ types:
             description: Invitation has been cancelled.
           401:
             description: The caller must be authenticated and authorised (logged-in) to use this resource
+          403:
+            description: The caller is not permitted to delete this invitation.
           404:
             description: The invitation with the specified id does not exist.
       get:
@@ -126,14 +132,15 @@ types:
                     },
                     "created": "2016-06-27T01:55:28+00.00",
                     "lastUpdated": "2016-07-02T01:55:28+00.00",
+                    "arn": "123451234512345",
                     "regime" : "sa",
-                    "agencyName" : "Sally Hughes Accountants",
-                    "agentName" : "Bob McCratchet",
                     "customerRegimeId" : "123456789",
                     "status": "pending"
                   }
           401:
             description: The caller must be authenticated and authorised (logged-in) to use this resource
+          403:
+            description: The caller is not permitted to see this invitation.
           404:
             description: The invitation with the specified id does not exist.
       uriParameters:
@@ -151,10 +158,10 @@ types:
         200:
           description: A list of invitations.
           body: Invitation[]
-        204:
-          description: No invitations matched the search criteria.
         401:
           description: The caller must be authenticated and authorised (logged-in) to use this resource
+        403:
+          description: The caller is not permitted to see this invitation.
     uriParameters:
       id:
         description: Customer identifier.
@@ -177,14 +184,15 @@ types:
                     },
                     "created": "2016-06-27T01:55:28+00.00",
                     "lastUpdated": "2016-07-02T01:55:28+00.00",
+                    "arn": "123451234512345",
                     "regime" : "sa",
-                    "agencyName" : "Sally Hughes Accountants",
-                    "agentName" : "Bob McCratchet",
                     "customerRegimeId" : "123456789",
                     "status": "pending"
                   }
           401:
             description: The caller must be authenticated and authorised (logged-in) to use this resource
+          403:
+            description: The caller is not permitted to see this invitation.
           404:
             description: The invitation with the specified id does not exist.
       uriParameters:
@@ -199,6 +207,8 @@ types:
               description: Invitation has been accepted.
             401:
               description: The caller must be authenticated and authorised (logged-in) to use this resource
+            403:
+              description: The caller is not permitted to accept this invitation.
             404:
               description: The invitation with the specified id does not exist.
       /reject:
@@ -209,5 +219,7 @@ types:
               description: Invitation has been rejected.
             401:
               description: The caller must be authenticated and authorised (logged-in) to use this resource
+            403:
+              description: The caller is not permitted to reject this invitation.
             404:
               description: The invitation with the specified id does not exist.


### PR DESCRIPTION
Updated after discussion with @howzat and story refinement

- Postcode will be supplied as part of the invitation and must be checked against the customer's details
- We need to support CT as well as SA UTRs
- Added 403 where appropriate
- Removed 204 for empty list responses
- Change mtdArn -> arn, documentation should be sufficient to identify _which_ arn
- Replaced agentName/agencyName with arn
