### PR TITLE
[FD][APB-5] Include explanatory body in error response for unsupported regime

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This code is open source software licensed under the [Apache 2.0 License]("http:
 
 [RAML documentation](invitations.raml)
 
+### Running the tests
+
+    sbt test it:test
+
 #### Unanswered Questions
 * ATTENTION!! Does auth convert ggAgentCodes to ARNs??
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/AgentClientAuthorisationISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/AgentClientAuthorisationISpec.scala
@@ -108,7 +108,10 @@ class AgentClientAuthorisationISpec extends UnitSpec with MongoAppAndStubs with 
 
     "should not create invitation for an unsupported regime" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      responseForCreateInvitation(s"""{"arn": "${arn.arn}", "regime": "sa", "customerRegimeId": "9876543210", "postcode": "A11 1AA"}""").status shouldBe 501
+      val response = responseForCreateInvitation(s"""{"arn": "${arn.arn}", "regime": "sa", "customerRegimeId": "9876543210", "postcode": "A11 1AA"}""")
+      response.status shouldBe 501
+      (response.json \ "code").as[String] shouldBe "UNSUPPORTED_REGIME"
+      (response.json \ "message").as[String] shouldBe "Unsupported regime \"sa\", the only currently supported regime is \"mtd-sa\""
     }
 
     "should create invitation if postcode has no spaces" in {


### PR DESCRIPTION
See https://confluence.tools.tax.service.gov.uk/display/ApiPlatform/Error+Handling for API platform guidelines on error responses.