### PR TITLE
[FD][APB-5] Terminology: "Client" instead of "Customer"

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/InvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/InvitationsController.scala
@@ -46,10 +46,10 @@ class InvitationsController(invitationsRepository: InvitationsRepository,
         ))
       else if (!validPostcode(authRequest.postcode))
         Future successful BadRequest
-      else if (!postcodeService.customerPostcodeMatches(authRequest.customerRegimeId, authRequest.postcode))
+      else if (!postcodeService.clientPostcodeMatches(authRequest.clientRegimeId, authRequest.postcode))
         Future successful Forbidden
       else
-        invitationsRepository.create(arn, authRequest.regime, authRequest.customerRegimeId, authRequest.postcode)
+        invitationsRepository.create(arn, authRequest.regime, authRequest.clientRegimeId, authRequest.postcode)
           .map(invitation => Created.withHeaders(location(invitation)))
     }
   }

--- a/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
@@ -61,7 +61,7 @@ case class Invitation(
   id: BSONObjectID,
   arn: Arn,
   regime: String,
-  customerRegimeId: String,
+  clientRegimeId: String,
   postcode: String,
   events: List[StatusChangeEvent]) {
 
@@ -76,7 +76,7 @@ case class Invitation(
 
 case class AgentClientAuthorisationHttpRequest(
   regime: String,
-  customerRegimeId: String,
+  clientRegimeId: String,
   postcode: String)
 
 object StatusChangeEvent {
@@ -94,7 +94,7 @@ object Invitation {
     def writes(invitation: Invitation) = Json.obj(
       "id" -> invitation.id.stringify,
       "regime" -> invitation.regime,
-      "customerRegimeId" -> invitation.customerRegimeId,
+      "clientRegimeId" -> invitation.clientRegimeId,
       "postcode" -> invitation.postcode,
       "arn" -> invitation.arn.arn,
       "created" -> invitation.firstEvent().time,

--- a/app/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsRepository.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsRepository.scala
@@ -31,13 +31,13 @@ import scala.concurrent.Future
 
 trait InvitationsRepository extends Repository[Invitation, BSONObjectID] {
 
-  def create(arn: Arn, regime: String, customerRegimeId: String, postcode: String): Future[Invitation]
+  def create(arn: Arn, regime: String, clientRegimeId: String, postcode: String): Future[Invitation]
 
   def update(id:BSONObjectID, status:InvitationStatus): Future[Invitation]
 
   def list(arn: Arn): Future[List[Invitation]]
 
-  def list(regime: String, customerRegimeId: String): Future[List[Invitation]]
+  def list(regime: String, clientRegimeId: String): Future[List[Invitation]]
 
 }
 
@@ -47,16 +47,16 @@ class InvitationsMongoRepository(implicit mongo: () => DB)
 
   override def indexes: Seq[Index] = Seq(
     Index(Seq("arn" -> IndexType.Ascending)),
-    Index(Seq("customerRegimeId" -> IndexType.Ascending))
+    Index(Seq("clientRegimeId" -> IndexType.Ascending))
   )
 
-  override def create(arn: Arn, regime: String, customerRegimeId: String, postcode: String): Future[Invitation] = withCurrentTime { now =>
+  override def create(arn: Arn, regime: String, clientRegimeId: String, postcode: String): Future[Invitation] = withCurrentTime { now =>
 
     val request = Invitation(
       id = BSONObjectID.generate,
       arn = arn,
       regime = regime,
-      customerRegimeId = customerRegimeId,
+      clientRegimeId = clientRegimeId,
       postcode = postcode,
       events = List(StatusChangeEvent(now, Pending))
     )
@@ -68,8 +68,8 @@ class InvitationsMongoRepository(implicit mongo: () => DB)
   override def list(arn: Arn): Future[List[Invitation]] =
     find("arn" -> arn.arn)
 
-  override def list(regime: String, customerRegimeId: String): Future[List[Invitation]] =
-    find("regime" -> regime, "customerRegimeId" -> customerRegimeId)
+  override def list(regime: String, clientRegimeId: String): Future[List[Invitation]] =
+    find("regime" -> regime, "clientRegimeId" -> clientRegimeId)
 
   override def update(id: BSONObjectID, status: InvitationStatus): Future[Invitation] = withCurrentTime { now =>
     val update = atomicUpdate(BSONDocument("_id" -> id), BSONDocument("$push" -> BSONDocument("events" -> bsonJson(StatusChangeEvent(now, status)))))

--- a/app/uk/gov/hmrc/agentclientauthorisation/service/PostcodeService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/service/PostcodeService.scala
@@ -17,6 +17,6 @@
 package uk.gov.hmrc.agentclientauthorisation.service
 
 class PostcodeService {
-  def customerPostcodeMatches(customerIdentifier: String, postcode: String) =
+  def clientPostcodeMatches(clientIdentifier: String, postcode: String) =
         postcode.startsWith("A")
 }

--- a/it/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsMongoRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsMongoRepositoryISpec.scala
@@ -43,12 +43,12 @@ class InvitationsMongoRepositoryISpec extends UnitSpec with MongoSpecSupport wit
     "create a new StatusChangedEvent of Pending" in {
 
       val arn = Arn("1")
-      val customerRegimeId = "1A"
+      val clientRegimeId = "1A"
 
-      inside(addInvitation((arn, "sa", customerRegimeId, "user-details"))) {
+      inside(addInvitation((arn, "sa", clientRegimeId, "user-details"))) {
         case event =>
           event.arn shouldBe arn
-          event.customerRegimeId shouldBe customerRegimeId
+          event.clientRegimeId shouldBe clientRegimeId
           event.regime shouldBe "sa"
           event.events.loneElement shouldBe StatusChangeEvent(now, Pending)
       }
@@ -83,7 +83,7 @@ class InvitationsMongoRepositoryISpec extends UnitSpec with MongoSpecSupport wit
       val requests = addInvitations((arn, "sa", saUtr1, "user-details-1"), (arn, "vat", vrn2, "user-details-2"))
       update(requests.last.id, Accepted)
 
-      val list = listByArn(arn).sortBy(_.customerRegimeId)
+      val list = listByArn(arn).sortBy(_.clientRegimeId)
 
       inside(list head) {
         case Invitation(_, `arn`, "sa", `saUtr1`, "user-details-1", List(StatusChangeEvent(date, Pending))) =>
@@ -110,7 +110,7 @@ class InvitationsMongoRepositoryISpec extends UnitSpec with MongoSpecSupport wit
   }
 
 
-  "AuthorisationRequestRepository listing by customerSaUtr" should {
+  "AuthorisationRequestRepository listing by clientSaUtr" should {
 
     "return an empty list when there is no such regime-regimeId pair" in {
       val regime = "sa"
@@ -139,32 +139,32 @@ class InvitationsMongoRepositoryISpec extends UnitSpec with MongoSpecSupport wit
       }
     }
 
-    "return a multiple requests for the same customer" in {
+    "return a multiple requests for the same client" in {
 
       val firstAgent = Arn("5")
       val secondAgent = Arn("6")
       val regime = "sa"
-      val customerSaUtr = "5A"
+      val clientSaUtr = "5A"
       val userDetailsLink = "user-details"
 
 
       addInvitations(
-        (firstAgent, regime, customerSaUtr, userDetailsLink),
-        (secondAgent, regime, customerSaUtr, userDetailsLink),
-        (Arn("should-not-show-up"), "sa", "another-customer", userDetailsLink)
+        (firstAgent, regime, clientSaUtr, userDetailsLink),
+        (secondAgent, regime, clientSaUtr, userDetailsLink),
+        (Arn("should-not-show-up"), "sa", "another-client", userDetailsLink)
       )
 
-      val requests = listByClientRegimeId(regime, customerSaUtr).sortBy(_.arn.arn)
+      val requests = listByClientRegimeId(regime, clientSaUtr).sortBy(_.arn.arn)
 
       requests.size shouldBe 2
 
       inside(requests head) {
-        case Invitation(_, `firstAgent`, `regime`, `customerSaUtr`, `userDetailsLink`, List(StatusChangeEvent(date, Pending))) =>
+        case Invitation(_, `firstAgent`, `regime`, `clientSaUtr`, `userDetailsLink`, List(StatusChangeEvent(date, Pending))) =>
           date shouldBe now
       }
 
       inside(requests(1)) {
-        case Invitation(_, `secondAgent`, `regime`, `customerSaUtr`, `userDetailsLink`, List(StatusChangeEvent(date, Pending))) =>
+        case Invitation(_, `secondAgent`, `regime`, `clientSaUtr`, `userDetailsLink`, List(StatusChangeEvent(date, Pending))) =>
           date shouldBe now
       }
     }
@@ -175,8 +175,8 @@ class InvitationsMongoRepositoryISpec extends UnitSpec with MongoSpecSupport wit
 
   private def addInvitations(invitations: Invitation*) = {
     await(Future sequence invitations.map {
-      case (code: Arn, regime: String, customerRegimeId: String, userDetailsLink: String) =>
-        repository.create(code, regime, customerRegimeId, userDetailsLink)
+      case (code: Arn, regime: String, clientRegimeId: String, userDetailsLink: String) =>
+        repository.create(code, regime, clientRegimeId, userDetailsLink)
     })
   }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/SecuredEndpointBehaviours.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/SecuredEndpointBehaviours.scala
@@ -31,7 +31,7 @@ trait SecuredEndpointBehaviours {
     }
 
     "return 401 when user is not an MTD agent" in {
-      given().customer().isLoggedIn("0123456789")
+      given().client().isLoggedIn("0123456789")
       request.status shouldBe 401
     }
   }
@@ -39,7 +39,7 @@ trait SecuredEndpointBehaviours {
   def anEndpointAccessibleForSaClientsOnly(request: => HttpResponse)(implicit me: Arn): Unit = {
     "return 401 when the requester is not authenticated" in {
       pending
-      given().customer().isNotLoggedIn()
+      given().client().isNotLoggedIn()
       request.status shouldBe 401
     }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/StubUtils.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/StubUtils.scala
@@ -35,7 +35,7 @@ trait StubUtils {
       new UnknownUser(oid)
     }
 
-    def customer(oid: String = "556737e15500005500eaf68f"): Client = {
+    def client(oid: String = "556737e15500005500eaf68f"): Client = {
       new Client(oid)
     }
   }


### PR DESCRIPTION
User research as presented by Kate suggests that accountants and their clients use "Client" not "Customer" and that some clients object to "Customer".

This commit only addresses the code - https://github.com/hmrc/agent-client-authorisation/pull/28 addresses the docs.