### PR TITLE
[FD][APB-150] encodePathSegments: include initial slash

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/UriPathEncoding.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/UriPathEncoding.scala
@@ -23,7 +23,7 @@ import play.utils.UriEncoding
 object UriPathEncoding {
 
   def encodePathSegments(pathSegments: String*): String =
-    pathSegments.map(encodePathSegment).mkString("/")
+    pathSegments.map(encodePathSegment).mkString("/", "/", "")
 
   def encodePathSegment(pathSegment: String): String =
     UriEncoding.encodePathSegment(pathSegment, StandardCharsets.UTF_8.name)

--- a/test/uk/gov/hmrc/agentclientauthorisation/UriPathEncodingSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/UriPathEncodingSpec.scala
@@ -21,15 +21,15 @@ import uk.gov.hmrc.play.test.UnitSpec
 class UriPathEncodingSpec extends UnitSpec {
   "encodePathSegments" should {
     "separate segments with forward slashes" in {
-      UriPathEncoding.encodePathSegments("one", "two", "three") shouldBe "one/two/three"
+      UriPathEncoding.encodePathSegments("one", "two", "three") shouldBe "/one/two/three"
     }
 
     "escape spaces using URL path encoding not form encoding" in {
-      UriPathEncoding.encodePathSegments("AA1 1AA") shouldBe "AA1%201AA"
+      UriPathEncoding.encodePathSegments("AA1 1AA") shouldBe "/AA1%201AA"
     }
 
     "protect against path traversal attacks" in {
-      UriPathEncoding.encodePathSegments("../bad", "ok") shouldBe "..%2Fbad/ok"
+      UriPathEncoding.encodePathSegments("../bad", "ok") shouldBe "/..%2Fbad/ok"
     }
   }
 


### PR DESCRIPTION
This is to keep agent-client-authorisation in sync with the changes made in https://github.com/hmrc/agent-client-authorisation-frontend/pull/51
