### PR TITLE
[FD,LA][APB-337] Remove invitation ID from API responses

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
@@ -111,7 +111,6 @@ object Invitation {
   implicit val oidFormats = ReactiveMongoFormats.objectIdFormats
   implicit val jsonWrites = new Writes[Invitation] {
     def writes(invitation: Invitation) = Json.obj(
-      "id" -> invitation.id.stringify,
       "regime" -> invitation.regime,
       "clientId" -> invitation.clientId,
       "postcode" -> invitation.postcode,

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,7 +2,7 @@
 POST     /agencies/:arn/invitations                             @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.createInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn)
 GET      /agencies/:arn/invitations/sent                        @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.getSentInvitations(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, regime: Option[String], clientId: Option[String], status: Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
 GET      /agencies/:arn/invitations/sent/:invitation            @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.getSentInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, invitation: String)
-DELETE   /agencies/:arn/invitations/sent/:invitation            @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.cancelInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, invitation: String)
+PUT      /agencies/:arn/invitations/sent/:invitation/cancel     @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.cancelInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, invitation: String)
 
 # Client routes
 


### PR DESCRIPTION
Also change cancel URL and verb to match RAML.

Do not merge until after https://github.com/hmrc/agent-client-authorisation-frontend/tree/apb-336-accepting-hateoas to avoid breaking the frontend.