### PR TITLE
[FD][APB-343] Don't spam the production logs with INFO messages

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,9 +5,11 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="INFO"/>
+    <logger name="uk.gov" level="WARN"/>
 
-    <root level="INFO">
+    <logger name="application" level="INFO"/>
+
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Note that app-config-prod/agent-client-authorisation.yaml has "logger.application: INFO" hence the <logger name="application" level="INFO"/> here.

https://hmrcdigital.slack.com/archives/event-play-upgrade/p1479317602001465
"play 2.5 does not respect the `logger.{logger root}: INFO` convention from application config used to override log levels and set them per environment
the only file that will currently define log levels in all environments is the `application-json-logger.xml` packaged with the application"