### PR TITLE
[FD] Use a random port for the test server

### DIFF
--- a/it/uk/gov/hmrc/agentclientauthorisation/support/AppAndStubs.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/AppAndStubs.scala
@@ -21,6 +21,7 @@ import org.scalatestplus.play.OneServerPerSuite
 import play.api.test.FakeApplication
 import uk.gov.hmrc.mongo.{Awaiting => MongoAwaiting, MongoSpecSupport}
 import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.it.Port
 
 import scala.concurrent.ExecutionContext
 
@@ -28,6 +29,8 @@ trait AppAndStubs extends StartAndStopWireMock with StubUtils with OneServerPerS
   me: Suite =>
 
   implicit val hc = HeaderCarrier()
+
+  override lazy val port: Int = Port.randomAvailable
 
   override implicit lazy val app: FakeApplication = FakeApplication(
     additionalConfiguration = additionalConfiguration


### PR DESCRIPTION
This allows multiple concurrent test runs (e.g. different branches in different directories) and reduces the risk of a port conflict on Jenkins.