### PR TITLE
[FD][APB-386] Make API private

### DIFF
--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -24,6 +24,16 @@
     "versions": [{
       "version": "0.0",
       "status": "PROTOTYPED",
+      "access": {
+        "type": "PRIVATE",
+        "whitelistedApplicationIds":[
+          "ab349380-17cc-4de0-a7ac-c76baedd7133",
+          "53f6fcb7-67b4-4801-8727-b8b2521e2904",
+          "6dfac0f3-370b-4306-8f51-d82e5c276faa",
+          "fa9ed720-f0e1-4268-8287-e23e03ae11cd",
+          "2f798389-1529-4cb7-a397-ddc482d15c07"
+        ]
+      },
       "endpoints": [{
         "uriPattern": "/agencies/{id}/invitations/sent",
         "endpointName": "Agency Sent Invitations",


### PR DESCRIPTION
This limits access to the application *and its documentation* to whitelisted applications.

See https://<confluence>/display/DTRG/Restricting+APIs+to+Private+Access+on+the+API+Platform

Currently whitelisted applications:
- API platform "Mandatory applications to whitelist" (see above confluence page) for all environments
- "Agents Test" applications in QA and Production

This is just a quick initial version - we should probably make the whitelist configurable as described on the confluence page.