### PR TITLE
APB 282 Contract Tests

### DIFF
--- a/it/uk/gov/hmrc/agentclientauthorisation/AgencyInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/AgencyInvitationsISpec.scala
@@ -16,114 +16,52 @@
 
 package uk.gov.hmrc.agentclientauthorisation
 
-import org.joda.time.DateTime
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{Inside, Inspectors}
-import play.api.Logger
-import play.api.libs.json._
-import play.mvc.Http.HeaderNames.LOCATION
 import reactivemongo.bson.BSONObjectID
-import uk.gov.hmrc.agentclientauthorisation.model.Arn
+import uk.gov.hmrc.agentclientauthorisation.model.{Arn, MtdClientId}
 import uk.gov.hmrc.agentclientauthorisation.support._
 import uk.gov.hmrc.domain.AgentCode
-import uk.gov.hmrc.play.controllers.RestFormats
-import uk.gov.hmrc.play.http.HttpResponse
+import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 import uk.gov.hmrc.play.test.UnitSpec
-import views.html.helper.urlEncode
 
-class AgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with Inspectors with Inside with Eventually with SecuredEndpointBehaviours {
-
-  import play.api.mvc.Codec.utf_8
+class AgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with Inspectors with Inside with Eventually with SecuredEndpointBehaviours with APIRequests {
 
   private implicit val arn = Arn("ABCDEF12345678")
   private implicit val agentCode = AgentCode("LMNOP123456")
 
-  private val clientId: String = "1234567890"
-
-  private val REGIME: String = "mtd-sa"
-  private val invitationsUrl = s"/agent-client-authorisation/agencies/${arn.arn}/invitations/sent"
-  private val getInvitationUrl = s"/agent-client-authorisation/agencies/${arn.arn}/invitations/sent/"
-
-
+  private val clientId: MtdClientId = MtdClientId("1234567890")
+  private val MtdRegime: Regime = Regime("mtd-sa")
+  private val validInvitation: AgencyInvitationRequest = AgencyInvitationRequest(MtdRegime, MtdClientId("1234567899"), "AA1 1AA")
 
   "GET /agencies/:arn/invitations/sent" should {
-    behave like anEndpointAccessibleForMtdAgentsOnly(responseForGetInvitations())
+    behave like anEndpointAccessibleForMtdAgentsOnly(agencyGetSentInvitations(arn))
 
     "return 403 for someone else's invitation list" in {
       given().agentAdmin(Arn("98765"), AgentCode("123456")).isLoggedIn().andHasMtdBusinessPartnerRecord()
-
-      val response = responseForGetInvitations()
-
+      val response = agencyGetSentInvitations(arn)
       response.status shouldBe 403
     }
-
-    "return only invitations for the specified client" in {
-      val clientId = "1234567890"
-      given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-
-      responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}""")
-      responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "9876543210", "postcode": "AA1 1AA"}""")
-
-      val response = responseForGetInvitationsByClient(clientId)
-
-      response.status shouldBe 200
-      val invitation = invitations(response.json)
-      invitation.value.size shouldBe 1
-      (invitation.value.head \ "clientId").as[String] shouldBe clientId
-      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe getInvitationsByClientUrl(clientId)
-    }
-
-    "return only invitations for the specified regime" in {
-      // TODO this test would fail at the time of writing because AgencyInvitationsController.createInvitation
-      // only allows invitations with regime = "mtd-sa" to be created
-      pending
-
-      val clientId = "1234567890"
-      given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-
-      responseForCreateInvitation(s"""{"regime": "mtd-other", "clientId": "$clientId", "postcode": "AA1 1AA"}""")
-      responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}""")
-
-      val response = responseForGetInvitationsByRegime("mtd-other")
-
-      response.status shouldBe 200
-      val invitation = invitations(response.json)
-      invitation.value.size shouldBe 1
-      (invitation.value.head \ "regime").as[String] shouldBe "mtd-other"
-      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe getInvitationsByRegimeUrl("mtd-other")
-    }
-
   }
 
   "POST /agencies/:arn/invitations" should {
-    val clientId = "1234567899"
-    behave like anEndpointAccessibleForMtdAgentsOnly(responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}"""))
+    behave like anEndpointAccessibleForMtdAgentsOnly{
+      agencySendInvitation(arn, validInvitation)
+    }
   }
 
   "GET /agencies/:arn/invitations/sent/:invitationId" should {
-    behave like anEndpointAccessibleForMtdAgentsOnly(responseForGetInvitation())
-
-    "Return a created invitation" in {
-      val testStartTime = DateTime.now().getMillis
-      given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      val clientId = "1234567899"
-      val location = responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}""").header("location")
-
-      val invitation = new Resource(location.get, port).get().json
-      checkInvitation(clientId, invitation, testStartTime)
-    }
+    behave like anEndpointAccessibleForMtdAgentsOnly(agencyGetSentInvitations(arn))
 
     "Return 404 for an invitation that doesn't exist" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-
-      val response = responseForGetInvitation(BSONObjectID.generate.stringify)
+      val response = agencyGetSentInvitation(arn, BSONObjectID.generate.stringify)
       response.status shouldBe 404
     }
 
     "Return 403 if accessing someone else's invitation" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      val clientId = "1234567899"
-      val location = responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}""").header("location")
+      val location = agencySendInvitation(arn, validInvitation).header("location")
 
       given().agentAdmin(Arn("98765"), AgentCode("123456")).isLoggedIn().andHasMtdBusinessPartnerRecord()
       val response = new Resource(location.get, port).get()
@@ -132,75 +70,20 @@ class AgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with Inspect
   }
 
   "/agencies/:arn/invitations" should {
-    "create and retrieve invitations" in {
-      val testStartTime = DateTime.now().getMillis
-      val (client1Id, client2Id) = createInvitations()
-
-      note("the freshly added invitations should be available")
-      val (responseJson, invitationsArray) = eventually {
-        // MongoDB is slow sometimes
-        val responseJson = responseForGetInvitations().json
-
-        Logger.info(s"responseJson = $responseJson")
-
-        val requestsArray = invitations(responseJson).value.sortBy(j => (j \ "clientId").as[String])
-        requestsArray should have size 2
-        (responseJson, requestsArray)
-      }
-
-      val selfLinkHref = (responseJson \ "_links" \ "self" \ "href").as[String]
-      selfLinkHref shouldBe invitationsUrl
-
-      val firstInvitation = invitationsArray head
-      val secondInvitation = invitationsArray(1)
-
-      val firstInvitationHref = checkInvitation(client1Id, firstInvitation, testStartTime)
-      val secondInvitationHref = checkInvitation(client2Id, secondInvitation, testStartTime)
-
-      firstInvitationHref should not be secondInvitationHref
-    }
-
-    "create and retrieve duplicate invitations" in {
-      val testStartTime = DateTime.now().getMillis
-      createDuplicateInvitations()
-
-      note("the freshly added invitations should be available")
-      val (responseJson, invitationsArray) = eventually {
-        // MongoDB is slow sometimes
-        val responseJson = responseForGetInvitations().json
-
-        Logger.info(s"responseJson = $responseJson")
-
-        val requestsArray = invitations(responseJson).value
-        requestsArray should have size 2
-        (responseJson, requestsArray)
-      }
-
-      val selfLinkHref = (responseJson \ "_links" \ "self" \ "href").as[String]
-      selfLinkHref shouldBe invitationsUrl
-
-      val firstInvitation = invitationsArray.head
-      val secondInvitation = invitationsArray(1)
-
-      val firstInvitationHref = checkInvitation("1234567890", firstInvitation, testStartTime)
-      val secondInvitationHref = checkInvitation("1234567890", secondInvitation, testStartTime)
-
-      firstInvitationHref should not be secondInvitationHref
-    }
 
     "should not create invitation if postcodes do not match" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "9876543210", "postcode": "BA1 1AA"}""").status shouldBe 403
+      agencySendInvitation(arn, validInvitation.copy(postcode = "BA1 1AA")).status shouldBe 403
     }
 
     "should not create invitation if postcode is not in a valid format" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "9876543210", "postcode": "BAn 1AA"}""").status shouldBe 400
+      agencySendInvitation(arn, validInvitation.copy(postcode = "BAn 1AA")).status shouldBe 400
     }
 
     "should not create invitation for an unsupported regime" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      val response = responseForCreateInvitation(s"""{"regime": "sa", "clientId": "9876543210", "postcode": "A11 1AA"}""")
+      val response = agencySendInvitation(arn, validInvitation.copy(regime = Regime("sa")))
       response.status shouldBe 501
       (response.json \ "code").as[String] shouldBe "UNSUPPORTED_REGIME"
       (response.json \ "message").as[String] shouldBe "Unsupported regime \"sa\", the only currently supported regime is \"mtd-sa\""
@@ -208,137 +91,23 @@ class AgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with Inspect
 
     "should create invitation if postcode has no spaces" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "9876543210", "postcode": "AA11AA"}""").status shouldBe 201
+      agencySendInvitation(arn, validInvitation.copy(postcode = "AA11AA")).status shouldBe 201
     }
 
     "should create invitation if postcode has more than one space" in {
       given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "9876543210", "postcode": "A A1 1A A"}""").status shouldBe 201
-    }
-  }
-
-  "PUT /agencies/:arn/invitations/sent/:invitationId/cancel" should {
-    behave like anEndpointAccessibleForMtdAgentsOnly(responseForCancelInvitation())
-
-    "should return 204 when invitation is Cancelled" in {
-      given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-      val clientId = "1234567899"
-      val location = responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}""").header("location")
-
-      val response = responseForCancelInvitation(location.get)
-
-      response.status shouldBe 204
-
+      agencySendInvitation(arn, validInvitation.copy(postcode = "A A1 1A A")).status shouldBe 201
     }
 
-  }
+    "PUT /agencies/:arn/invitations/sent/:invitationId/cancel" should {
+      behave like anEndpointAccessibleForMtdAgentsOnly(agencyCancelInvitation(arn, "invitaionId"))
 
-  private def checkInvitation(client2Id: String, invitation: JsValue, testStartTime: Long): String = {
-    implicit val dateReads = RestFormats.dateTimeRead
-    val beRecent = be >= testStartTime and be <= (testStartTime + 5000)
-    val selfLinkHref = (invitation \ "_links" \ "self" \ "href").as[String]
-    selfLinkHref should startWith(s"/agent-client-authorisation/agencies/${arn.arn}/invitations/sent/")
-    (invitation \ "_links" \ "cancel" \ "href").as[String] shouldBe s"$selfLinkHref/cancel"
-    (invitation \ "_links" \ "agency" \ "href").as[String] shouldBe s"http://localhost:$wiremockPort/agencies-fake/agencies/${arn.arn}"
-    (invitation \ "arn").as[String] shouldBe arn.arn
-    (invitation \ "regime").as[String] shouldBe REGIME
-    (invitation \ "clientId").as[String] shouldBe client2Id
-    (invitation \ "status").as[String] shouldBe "Pending"
-    (invitation \ "created").as[DateTime].getMillis should beRecent
-    (invitation \ "lastUpdated").as[DateTime].getMillis should beRecent
-    selfLinkHref
-  }
-
-  def createInvitations(): (String, String) = {
-    dropMongoDb()
-    given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-    val client1Id = "1234567890"
-    val client2Id = "1234567891"
-
-    note("there should be no requests")
-    eventually {
-      inside(responseForGetInvitations()) { case resp =>
-        resp.status shouldBe 200
-        invitations(resp.json).value shouldBe 'empty
+      "should return 204 when invitation is Cancelled" ignore {
+        given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
+        val location = agencySendInvitation(arn, validInvitation.copy(postcode = "AA11AA")).header("location")
+        val response = agencyGetSentInvitation(arn, location.get)
+        response.status shouldBe 204
       }
     }
-
-    note("we should be able to add 2 new requests")
-    val location1: String = checkCreatedResponse(responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$client1Id", "postcode": "AA1 1AA"}"""))
-    val location2: String = checkCreatedResponse(responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$client2Id", "postcode": "AA1 1AA"}"""))
-
-    val json1: JsValue = new Resource(location1, port).get().json
-    val json2: JsValue = new Resource(location2, port).get().json
-
-    (invitation(json1), invitation(json2))
-  }
-
-
-  private def createDuplicateInvitations(): Unit = {
-    dropMongoDb()
-    given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-    val clientId = "1234567890"
-
-    note("there should be no requests")
-    eventually {
-      inside(responseForGetInvitations()) { case resp =>
-        resp.status shouldBe 200
-        invitations(resp.json).value shouldBe 'empty
-      }
-    }
-
-    note("we should be able to add 2 new requests")
-    val location1: String = checkCreatedResponse(responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}"""))
-    val location2: String = checkCreatedResponse(responseForCreateInvitation(s"""{"regime": "$REGIME", "clientId": "$clientId", "postcode": "AA1 1AA"}"""))
-
-    val json1: JsValue = new Resource(location1, port).get().json
-    val json2: JsValue = new Resource(location2, port).get().json
-  }
-
-  private def invitation(json: JsValue): String = {
-    (json \ "clientId").as[String]
-  }
-
-  private def invitations(response: JsValue) = {
-    val embedded = (response \ "_embedded" \ "invitations").get
-    embedded match {
-      case array: JsArray => array
-      case obj: JsObject => JsArray(Seq(obj))
-    }
-  }
-
-  private def responseForGetInvitations(): HttpResponse = {
-    new Resource(invitationsUrl, port).get()
-  }
-
-  private def responseForCancelInvitation(invitation: String = getInvitationUrl + "none"): HttpResponse = {
-    new Resource(invitation + "/cancel", port).putEmpty()
-  }
-
-  private def responseForGetInvitationsByRegime(regime: String): HttpResponse = {
-    new Resource(getInvitationsByRegimeUrl(regime), port).get()
-  }
-
-  private def getInvitationsByRegimeUrl(regime: String): String = invitationsUrl + s"?regime=${urlEncode(regime)}"
-
-  private def responseForGetInvitationsByClient(clientId: String): HttpResponse = {
-    new Resource(getInvitationsByClientUrl(clientId), port).get()
-  }
-
-  private def getInvitationsByClientUrl(clientId: String): String = invitationsUrl + s"?clientId=${urlEncode(clientId)}"
-
-  private def responseForGetInvitation(invitationId: String = "none"): HttpResponse = {
-    new Resource(getInvitationUrl + invitationId, port).get()
-  }
-
-  private def responseForCreateInvitation(body: String): HttpResponse = {
-    new Resource(invitationsUrl, port).postAsJson(body)
-  }
-  private def checkCreatedResponse(httpResponse: HttpResponse) = {
-    httpResponse.status shouldBe 201
-    val expectedUri: String = httpResponse.header(LOCATION).get
-    expectedUri should startWith (s"/agent-client-authorisation/agencies/${arn.arn}/invitations/sent/")
-    expectedUri
   }
 }
-

--- a/it/uk/gov/hmrc/agentclientauthorisation/ClientInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/ClientInvitationsISpec.scala
@@ -16,230 +16,67 @@
 
 package uk.gov.hmrc.agentclientauthorisation
 
-import java.net.URI
-
-import org.joda.time.DateTime
-import org.joda.time.DateTime.now
 import org.scalatest.Inside
 import org.scalatest.concurrent.Eventually
-import play.api.libs.json.{JsArray, JsValue}
-import uk.gov.hmrc.agentclientauthorisation.model.{Arn, MtdClientId}
-import uk.gov.hmrc.agentclientauthorisation.support.{FakeMtdClientId, MongoAppAndStubs, Resource, SecuredEndpointBehaviours}
+import uk.gov.hmrc.agentclientauthorisation.model.Arn
+import uk.gov.hmrc.agentclientauthorisation.support._
 import uk.gov.hmrc.domain.AgentCode
-import uk.gov.hmrc.play.controllers.RestFormats
-import uk.gov.hmrc.play.http.HttpResponse
+import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 import uk.gov.hmrc.play.test.UnitSpec
 
-class ClientInvitationsISpec extends UnitSpec with MongoAppAndStubs with SecuredEndpointBehaviours with Eventually with Inside {
+class ClientInvitationsISpec extends UnitSpec with MongoAppAndStubs with SecuredEndpointBehaviours with Eventually with Inside with APIRequests {
 
   private implicit val arn = Arn("ABCDEF12345678")
   private implicit val agentCode = AgentCode("LMNOP123456")
   private val mtdClientId = FakeMtdClientId.random()
   private val mtdClient2Id = FakeMtdClientId.random()
-  private val REGIME = "mtd-sa"
-
-  private val createInvitationUrl = s"/agent-client-authorisation/agencies/${arn.arn}/invitations/sent"
-  private val getInvitationUrl = s"/agent-client-authorisation/clients/${mtdClientId.value}/invitations/received/"
-  private def getInvitationsUrl(clientId: MtdClientId = mtdClientId) = s"/agent-client-authorisation/clients/${clientId.value}/invitations/received"
-
+  private val MtdRegime = Regime("mtd-sa")
 
 
   "PUT of /clients/:clientId/invitations/received/:invitationId/accept" should {
-    behave like anEndpointAccessibleForSaClientsOnly(responseForAcceptInvitation())
-
-    "accept a pending request" in {
-      val invitationUri = createInvitationForClient()
-
-      given().client(clientId = mtdClientId).isLoggedIn()
-        .aRelationshipIsCreatedWith(arn)
-
-      acceptInvitation(invitationUri)
-    }
+    behave like anEndpointAccessibleForSaClientsOnly(mtdClientId)(clientAcceptInvitation(mtdClientId, "invitation-id-not-used"))
   }
 
   "PUT of /clients/:clientId/invitations/received/:invitationId/reject" should {
-    behave like anEndpointAccessibleForSaClientsOnly(responseForRejectInvitation())
-
-    "reject a pending request" in {
-      val invitationId = createInvitationForClient()
-      given().client(clientId = mtdClientId).isLoggedIn()
-
-      val response = responseForRejectInvitation(invitationId)
-
-      response.status shouldBe 204
-    }
-
+    behave like anEndpointAccessibleForSaClientsOnly(mtdClientId)(clientRejectInvitation(mtdClientId, "invitation-id-not-used"))
   }
 
   "GET /clients/:clientId/invitations/received" should {
-    behave like anEndpointAccessibleForSaClientsOnly(responseForGetClientInvitations())
-
-    "return a 200 response" in {
-      createInvitations()
-
-      given().client(clientId = mtdClientId).isLoggedIn()
-
-      val response = new Resource(s"/agent-client-authorisation/clients/${mtdClientId.value}/invitations/received", port).get
-      response.status shouldBe 200
-
-      val json: JsValue = response.json
-      val invitation = invitations(json)
-      invitation.value.size shouldBe 1
-    }
-
-    "return more than one invitation" in {
-      createInvitations()
-      createInvitations()
-
-      given().client(clientId = mtdClientId).isLoggedIn()
-
-      val response = new Resource(s"/agent-client-authorisation/clients/${mtdClientId.value}/invitations/received", port).get
-      response.status shouldBe 200
-
-      val json: JsValue = response.json
-      val invitation = invitations(json)
-      invitation.value.size shouldBe 2
-    }
-
-    "return only invitations with the specified status" in {
-      val invitationUriToAccept = createInvitationForClient()
-      createInvitation()
-
-      given().client(clientId = mtdClientId).isLoggedIn()
-        .aRelationshipIsCreatedWith(arn)
-      acceptInvitation(invitationUriToAccept)
-
-      given().client(clientId = mtdClientId).isLoggedIn()
-
-      val acceptedInvitationsUrl = s"/agent-client-authorisation/clients/${mtdClientId.value}/invitations/received?status=Accepted"
-      val response = new Resource(acceptedInvitationsUrl, port).get
-      response.status shouldBe 200
-
-      val json: JsValue = response.json
-      val invitation = invitations(json)
-      invitation.value.size shouldBe 1
-
-      (json \ "_links" \ "self" \ "href").as[String] shouldBe acceptedInvitationsUrl
-    }
-
-    "return a 401 response if not logged-in" in {
-
-      given().client().isNotLoggedIn()
-      responseForGetClientInvitations().status shouldBe 401
-    }
+    behave like anEndpointAccessibleForSaClientsOnly(mtdClientId)(clientGetReceivedInvitations(mtdClientId))
 
     "return 404 when try to access someone else's invitations" in {
-      createInvitations()
 
       given().client(clientId = mtdClientId).isLoggedIn()
-
-      val response = new Resource(s"/agent-client-authorisation/clients/${mtdClient2Id.value}/invitations/received", port).get
-
-      response.status shouldBe 403
+      clientGetReceivedInvitations(mtdClient2Id).status shouldBe 403
     }
   }
 
   "GET /clients/:clientId/invitations/received/:invitation" should {
-    behave like anEndpointAccessibleForSaClientsOnly(responseForGetClientInvitations())
-
-    "return a 200 response" in {
-
-      val testStartTime = now().getMillis
-      val invitationUri = createInvitationForClient()
-      invitationUri.getPath should startWith(s"/agent-client-authorisation/clients/${mtdClientId.value}/invitations/received/")
-
-      given().client(clientId = mtdClientId).isLoggedIn()
-
-      val response = responseForGetClientInvitation(invitationUri)
-      response.status shouldBe 200
-
-      val invitation = response.json
-      checkInvitation(mtdClientId, invitation, testStartTime)
-    }
-
-    "return a 401 response if not logged-in" in {
-      val invitationUri = createInvitationForClient()
-      invitationUri.getPath should startWith(s"/agent-client-authorisation/clients/${mtdClientId.value}/invitations/received/")
-
-      given().client().isNotLoggedIn()
-      responseForGetClientInvitation(invitationUri).status shouldBe 401
-    }
+    val invitationId: String = "invite-id-never-used"
+    behave like anEndpointAccessibleForSaClientsOnly(mtdClientId)(clientGetReceivedInvitation(mtdClientId, invitationId))
 
     "return 404 when invitation not found" in {
-      val response = responseForGetClientInvitation(new URI(getInvitationUrl + "none"))
+      val response = clientGetReceivedInvitation(mtdClientId, invitationId)
       response.status shouldBe 404
     }
 
     "return 403 when try to access someone else's invitation" in {
-      val invitationUri = createInvitationForClient(mtdClient2Id)
 
-      given().client(clientId = mtdClientId).isLoggedIn()
-      val response = responseForGetClientInvitation(invitationUri)
+      val agency = new AgencyApi(arn, port)
+      given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
+
+      agency.sendInvitation(mtdClient2Id)
+
+      val client = new ClientApi(mtdClient2Id, port)
+      given().client(clientId = client.clientId).isLoggedIn()
+      val invitations = client.getInvitations()
+      val invite = invitations.firstInvitation
+
+      val client2 = new ClientApi(mtdClientId, port)
+      given().client(clientId = client2.clientId).isLoggedIn()
+
+      val response = updateInvitationResource(invite.links.acceptLink.get)(port, client2.hc)
       response.status shouldBe 403
     }
-  }
-
-  def responseForGetClientInvitations(clientId: MtdClientId = mtdClientId): HttpResponse = {
-    new Resource(getInvitationsUrl(clientId), port).get()
-  }
-
-  def responseForGetClientInvitation(invitationUri: URI): HttpResponse = {
-    new Resource(invitationUri.toString, port).get()
-  }
-
-  private def createInvitation(body: String = s"""{"regime": "$REGIME", "clientId": "${mtdClientId.value}", "postcode": "AA1 1AA"}"""): Unit = {
-    given().agentAdmin(arn, agentCode).isLoggedIn().andHasMtdBusinessPartnerRecord()
-    new Resource(createInvitationUrl, port).postAsJson(body)
-  }
-
-  private def createInvitationForClient(clientId: MtdClientId = mtdClientId): URI = {
-    createInvitation(s"""{"regime": "$REGIME", "clientId": "${clientId.value}", "postcode": "AA1 1AA"}""")
-
-    given().client(clientId = clientId).isLoggedIn()
-
-    val response = responseForGetClientInvitations(clientId)
-    response.status shouldBe 200
-
-    val invitationsArray = invitations(response.json)
-    invitationsArray.value.size shouldBe 1
-    new URI(getInvitationsUrl(clientId)).resolve(
-      (invitationsArray(0) \ "_links" \ "self" \ "href").as[String])
-  }
-
-  private def checkInvitation(clientId: MtdClientId, invitation: JsValue, testStartTime: Long): Unit = {
-    implicit val dateTimeRead = RestFormats.dateTimeRead
-    val beRecent = be >= testStartTime and be <= (testStartTime + 5000)
-    val selfHref = (invitation \ "_links" \ "self" \ "href").as[String]
-    selfHref should startWith(s"/agent-client-authorisation/clients/${clientId.value}/invitations/received/")
-    (invitation \ "_links" \ "accept" \ "href").as[String] shouldBe s"$selfHref/accept"
-    (invitation \ "_links" \ "reject" \ "href").as[String] shouldBe s"$selfHref/reject"
-    (invitation \ "arn").as[String] shouldBe arn.arn
-    (invitation \ "regime").as[String] shouldBe REGIME
-    (invitation \ "clientId").as[String] shouldBe clientId.value
-    (invitation \ "status").as[String] shouldBe "Pending"
-    (invitation \ "created").as[DateTime].getMillis should beRecent
-    (invitation \ "lastUpdated").as[DateTime].getMillis should beRecent
-  }
-
-  private def invitations(response: JsValue) = {
-    (response \ "_embedded" \ "invitations").as[JsArray]
-  }
-
-  private def createInvitations(): Unit = {
-    createInvitation()
-    createInvitation(s"""{"regime": "$REGIME", "clientId": "${mtdClient2Id.value}", "postcode": "AA1 1AA"}""")
-  }
-
-  private def responseForRejectInvitation(invitationUri: URI = new URI(getInvitationUrl + "none")): HttpResponse = {
-    new Resource(invitationUri.toString + "/reject", port).putEmpty()
-  }
-
-  private def responseForAcceptInvitation(invitationUri: URI = new URI(getInvitationUrl + "none")): HttpResponse = {
-    new Resource(invitationUri.toString + "/accept", port).putEmpty()
-  }
-
-  private def acceptInvitation(invitationUri: URI): Unit = {
-    val response = responseForAcceptInvitation(invitationUri)
-    response.status shouldBe 204
   }
 }

--- a/it/uk/gov/hmrc/agentclientauthorisation/scenarios/AgencyFiltersByRegimeISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/scenarios/AgencyFiltersByRegimeISpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.concurrent.Eventually
 import uk.gov.hmrc.agentclientauthorisation.model.MtdClientId
 import uk.gov.hmrc.agentclientauthorisation.support._
 import uk.gov.hmrc.domain.AgentCode
-import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 
 class AgencyFiltersByRegimeISpec extends FeatureSpec with ScenarioHelpers with GivenWhenThen with Matchers with MongoAppAndStubs with Inspectors with Inside with Eventually {
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
@@ -16,22 +16,6 @@
 
 package uk.gov.hmrc.agentclientauthorisation.support
 
-/*
- * Copyright 2016 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import uk.gov.hmrc.agentclientauthorisation.model.{Arn, MtdClientId}
 import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.support
+
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+import uk.gov.hmrc.agentclientauthorisation.model.{Arn, MtdClientId}
+import uk.gov.hmrc.play.auth.microservice.connectors.Regime
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import views.html.helper._
+
+trait APIRequests {
+
+  private def agencyGetInvitationsUrl(arn:Arn): String = s"/agent-client-authorisation/agencies/${arn.arn}/invitations/sent"
+  private def agencyGetInvitationUrl(arn:Arn, invitationId:String): String = s"/agent-client-authorisation/agencies/${arn.arn}/$invitationId"
+  private def clientGetReceivedInvitationsUrl(id:MtdClientId): String = s"/agent-client-authorisation/clients/${urlEncode(id.value)}/invitations/received"
+
+  def agencyGetSentInvitationsRequest(arn:Arn, filteredBy:Seq[(String, String)] = Nil)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+    val params = withFilterParams(filteredBy)
+    new Resource(agencyGetInvitationsUrl(arn)+params, port).get()(hc)
+  }
+
+  def agencyGetSentInvitationRequest(arn:Arn, invitationId:String)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+    new Resource(agencyGetInvitationUrl(arn, invitationId), port).get()(hc)
+  }
+
+  case class AgencyInvitationRequest(regime:Regime, clientId:MtdClientId, postcode:String) {
+    val json: String = s"""{"regime": "${regime.value}", "clientId": "${clientId.value}", "postcode": "$postcode"}"""
+  }
+
+  def agencyPostInvitationRequest(arn:Arn, invitation:AgencyInvitationRequest)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+    val url: String = agencyGetInvitationsUrl(arn)
+    new Resource(url, port).postAsJson(invitation.json)
+  }
+
+  def clientGetReceivedInvitations(filteredBy: Seq[(String, String)], clientId: MtdClientId)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+    val params = withFilterParams(filteredBy)
+    new Resource(clientGetReceivedInvitationsUrl(clientId) + params, port).get()(hc)
+  }
+
+  def updateInvitationStatus(link: String)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+    val response: HttpResponse = new Resource(link, port).putEmpty()(hc)
+    require(response.status == 204, s"response for PUT on invitation should be 204, was [${response.status}]")
+    response
+  }
+
+  def withFilterParams(filteredBy: Seq[(String, String)]): String = {
+    filteredBy match {
+      case Nil => ""
+      case (k, v) :: Nil => s"?$k=$v"
+      case (k, v) :: tail => s"?$k=$v" + tail.map(params => s"&${params._1}=${params._2}").mkString
+    }
+  }
+}

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
@@ -32,46 +32,70 @@ package uk.gov.hmrc.agentclientauthorisation.support
  * limitations under the License.
  */
 
-
-
 import uk.gov.hmrc.agentclientauthorisation.model.{Arn, MtdClientId}
 import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 import views.html.helper._
 
+
 trait APIRequests {
 
-  private def agencyGetInvitationsUrl(arn:Arn): String = s"/agent-client-authorisation/agencies/${arn.arn}/invitations/sent"
-  private def agencyGetInvitationUrl(arn:Arn, invitationId:String): String = s"/agent-client-authorisation/agencies/${arn.arn}/$invitationId"
-  private def clientGetReceivedInvitationsUrl(id:MtdClientId): String = s"/agent-client-authorisation/clients/${urlEncode(id.value)}/invitations/received"
+  def sandboxMode:Boolean = false
 
-  def agencyGetSentInvitationsRequest(arn:Arn, filteredBy:Seq[(String, String)] = Nil)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+  private def baseUrl = if(sandboxMode) "/agent-client-authorisation/sandbox" else "/agent-client-authorisation"
+  private def agencyGetInvitationsUrl(arn: Arn): String = s"$baseUrl/agencies/${arn.arn}/invitations/sent"
+  private def agencyGetInvitationUrl(arn: Arn, invitationId: String): String = s"$baseUrl/agencies/${arn.arn}/invitations/sent/$invitationId"
+
+  def agencyGetSentInvitations(arn: Arn, filteredBy: Seq[(String, String)] = Nil)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
     val params = withFilterParams(filteredBy)
-    new Resource(agencyGetInvitationsUrl(arn)+params, port).get()(hc)
+    new Resource(agencyGetInvitationsUrl(arn) + params, port).get()(hc)
   }
 
-  def agencyGetSentInvitationRequest(arn:Arn, invitationId:String)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+  def agencyGetSentInvitation(arn: Arn, invitationId: String)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
     new Resource(agencyGetInvitationUrl(arn, invitationId), port).get()(hc)
   }
 
-  case class AgencyInvitationRequest(regime:Regime, clientId:MtdClientId, postcode:String) {
+  case class AgencyInvitationRequest(regime: Regime, clientId: MtdClientId, postcode: String) {
     val json: String = s"""{"regime": "${regime.value}", "clientId": "${clientId.value}", "postcode": "$postcode"}"""
   }
 
-  def agencyPostInvitationRequest(arn:Arn, invitation:AgencyInvitationRequest)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
+  def agencySendInvitation(arn: Arn, invitation: AgencyInvitationRequest)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
     val url: String = agencyGetInvitationsUrl(arn)
     new Resource(url, port).postAsJson(invitation.json)
   }
 
-  def clientGetReceivedInvitations(filteredBy: Seq[(String, String)], clientId: MtdClientId)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
-    val params = withFilterParams(filteredBy)
-    new Resource(clientGetReceivedInvitationsUrl(clientId) + params, port).get()(hc)
+  def agencyCancelInvitation(arn: Arn, invitationId: String)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
+    val url: String = agencyGetInvitationUrl(arn, invitationId) + "/cancel"
+    new Resource(url, port).putEmpty()
   }
 
-  def updateInvitationStatus(link: String)(implicit port:Int, hc:HeaderCarrier): HttpResponse = {
-    val response: HttpResponse = new Resource(link, port).putEmpty()(hc)
-    require(response.status == 204, s"response for PUT on invitation should be 204, was [${response.status}]")
-    response
+  /*
+  CLIENT RELATED RESOURCES
+  TODO:  split these into seperate traits?
+   */
+
+  private def clientReceivedInvitationsUrl(id: MtdClientId): String = s"$baseUrl/clients/${urlEncode(id.value)}/invitations/received"
+  private def clientReceivedInvitationUrl(id: MtdClientId, invitationId:String): String = s"$baseUrl/clients/${urlEncode(id.value)}/invitations/received/$invitationId"
+
+  def clientGetReceivedInvitations(clientId: MtdClientId, filteredBy: Seq[(String, String)] = Nil)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
+    val params = withFilterParams(filteredBy)
+    new Resource(clientReceivedInvitationsUrl(clientId) + params, port).get()(hc)
+  }
+
+  def clientGetReceivedInvitation(clientId: MtdClientId, invitationId: String)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
+    new Resource(clientReceivedInvitationUrl(clientId, invitationId), port).get()(hc)
+  }
+
+  def clientAcceptInvitation(clientId: MtdClientId, invitationId:String)(implicit port: Int, hc: HeaderCarrier) = {
+    updateInvitationResource(clientReceivedInvitationsUrl(clientId) + s"/$invitationId/accept")
+  }
+
+  def clientRejectInvitation(clientId: MtdClientId, invitationId:String)(implicit port: Int, hc: HeaderCarrier) =
+    updateInvitationResource(clientReceivedInvitationsUrl(clientId) + s"/$invitationId/reject")
+
+  def updateInvitationResource(link: String)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
+    println(link)
+    new Resource(link, port).putEmpty()(hc)
   }
 
   def withFilterParams(filteredBy: Seq[(String, String)]): String = {

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/AgencyApi.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/AgencyApi.scala
@@ -30,14 +30,21 @@ class AgencyApi(val arn: Arn, implicit val port: Int) extends APIRequests {
 
   def sendInvitation(clientId: MtdClientId, regime: Regime = Regime("mtd-sa"), postcode:String = "AA1 1AA"): String = {
 
-    val response = agencyPostInvitationRequest(arn, AgencyInvitationRequest(regime, clientId, postcode))
+    val response = agencySendInvitation(arn, AgencyInvitationRequest(regime, clientId, postcode))
     require(response.status == 201, s"Creating an invitation should return 201, was [${response.status}]")
     response.header(LOCATION).get
   }
 
   def sentInvitations(filteredBy:Seq[(String, String)] = Nil): HalResourceHelper = {
 
-    val response = agencyGetSentInvitationsRequest(arn, filteredBy)
+    val response = agencyGetSentInvitations(arn, filteredBy)
+    require(response.status == 200, s"Couldn't get invitations, response status [${response.status}]")
+    HalTestHelpers(response.json)
+  }
+
+  def sentInvitation(invitationId:String): HalResourceHelper = {
+
+    val response = agencyGetSentInvitation(arn, invitationId)
     require(response.status == 200, s"Couldn't get invitations, response status [${response.status}]")
     HalTestHelpers(response.json)
   }

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/AppAndStubs.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/AppAndStubs.scala
@@ -29,6 +29,7 @@ trait AppAndStubs extends StartAndStopWireMock with StubUtils with OneServerPerS
   me: Suite =>
 
   implicit val hc = HeaderCarrier()
+  implicit val portNum = port
 
   override lazy val port: Int = Port.randomAvailable
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/ClientApi.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/ClientApi.scala
@@ -28,17 +28,17 @@ class ClientApi(val clientId: MtdClientId, implicit val port: Int) extends Event
   implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(clientId.value)))
 
   def acceptInvitation(invitation: EmbeddedInvitation): HttpResponse = {
-    invitation.links.acceptLink.map (updateInvitationStatus)
+    invitation.links.acceptLink.map (updateInvitationResource)
       .getOrElse (throw new IllegalStateException("Can't accept this invitation the accept link is not defined"))
   }
 
   def rejectInvitation(invitation: EmbeddedInvitation): HttpResponse = {
-    invitation.links.rejectLink.map(updateInvitationStatus)
+    invitation.links.rejectLink.map(updateInvitationResource)
       .getOrElse (throw new IllegalStateException("Can't reject this invitation the reject link is not defined"))
   }
 
   def getInvitations(filteredBy: Seq[(String, String)] = Nil): HalResourceHelper = {
-    val response = clientGetReceivedInvitations(filteredBy, clientId)(port, hc)
+    val response = clientGetReceivedInvitations(clientId, filteredBy)(port, hc)
     require(response.status == 200, s"Couldn't get invitations, response status [${response.status}]")
     HalTestHelpers(response.json)
   }

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/ScenarioHelpers.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/ScenarioHelpers.scala
@@ -17,12 +17,14 @@
 package uk.gov.hmrc.agentclientauthorisation.support
 
 import org.scalatest._
+import org.scalatest.concurrent.Eventually
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentclientauthorisation.support.EmbeddedSection.EmbeddedInvitation
 import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 
-trait ScenarioHelpers {
-  me : FeatureSpec with Matchers =>
+trait ScenarioHelpers extends APIRequests with Matchers with Eventually {
+
+  self : FeatureSpec =>
 
   def mtdClientId: MtdClientId
   def arn: Arn
@@ -92,5 +94,4 @@ trait ScenarioHelpers {
     refetchedInvitations.firstInvitation.status shouldBe "Accepted"
     refetchedInvitations.secondInvitation.status shouldBe "Pending"
   }
-
 }

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/SecuredEndpointBehaviours.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/SecuredEndpointBehaviours.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.agentclientauthorisation.support
 
-import uk.gov.hmrc.agentclientauthorisation.model.Arn
+import uk.gov.hmrc.agentclientauthorisation.model.{Arn, MtdClientId}
 import uk.gov.hmrc.domain.AgentCode
 import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.play.test.UnitSpec
@@ -24,7 +24,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 trait SecuredEndpointBehaviours {
   this: UnitSpec with AppAndStubs =>
 
-  def anEndpointAccessibleForMtdAgentsOnly(request: => HttpResponse)(implicit me: Arn): Unit = {
+  def anEndpointAccessibleForMtdAgentsOnly(request: => HttpResponse): Unit = {
     "return 401 when the requester is not authenticated" in {
       given().user().isNotLoggedIn()
       request.status shouldBe 401
@@ -36,14 +36,14 @@ trait SecuredEndpointBehaviours {
     }
   }
 
-  def anEndpointAccessibleForSaClientsOnly(request: => HttpResponse)(implicit me: Arn): Unit = {
+  def anEndpointAccessibleForSaClientsOnly(id: MtdClientId)(request: => HttpResponse): Unit = {
     "return 401 when the requester is not authenticated" in {
-      given().client().isNotLoggedIn()
+      given().client(clientId = id).isNotLoggedIn()
       request.status shouldBe 401
     }
 
     "return 401 when user has no SA account" in {
-      given().agentAdmin(me, AgentCode("12345")).isLoggedIn().andHasMtdBusinessPartnerRecord()
+      given().agentAdmin(RandomArn(), AgentCode("12345")).isLoggedIn().andHasMtdBusinessPartnerRecord()
       request.status shouldBe 401
     }
   }

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/halTestHelpers.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/halTestHelpers.scala
@@ -27,10 +27,10 @@ object HalTestHelpers {
   def apply(json: JsValue) = new HalResourceHelper(json)
 
   class HalResourceHelper(json: JsValue) {
-    def embedded: EmbeddedSection = new EmbeddedSection(json \ "_embedded")
-    def links: LinkSection = new LinkSection(json \ "_links")
+    def embedded: EmbeddedSection = new EmbeddedSection((json \ "_embedded").as[JsValue])
+    def links: LinkSection = new LinkSection((json \ "_links").as[JsValue])
     def numberOfInvitations = embedded.invitations.size
-    def firstInvitation = embedded.invitations.head
+    def firstInvitation: EmbeddedInvitation = embedded.invitations.head
     def secondInvitation = embedded.invitations(1)
   }
 }
@@ -38,10 +38,10 @@ object HalTestHelpers {
 object EmbeddedSection {
 
   case class EmbeddedInvitationLinks(selfLink: String, agencyLink:Option[String], cancelLink: Option[String], acceptLink: Option[String], rejectLink: Option[String])
-  case class EmbeddedInvitation(links: EmbeddedInvitationLinks, arn: Arn, regime: Regime, clientId: MtdClientId, status: String, created: DateTime, lastUpdated: DateTime)
+  case class EmbeddedInvitation(underlying:JsValue, links: EmbeddedInvitationLinks, arn: Arn, regime: Regime, clientId: MtdClientId, status: String, created: DateTime, lastUpdated: DateTime)
 }
 
-class EmbeddedSection(embedded: JsLookupResult) {
+class EmbeddedSection(embedded: JsValue) {
 
   def isEmpty: Boolean = invitations isEmpty
 
@@ -63,6 +63,7 @@ class EmbeddedSection(embedded: JsLookupResult) {
     def getDateTime(path: JsLookupResult) = path.as[DateTime]
 
     EmbeddedInvitation(
+      underlying = invitation,
       EmbeddedInvitationLinks(
         getString(invitation \ "_links" \ "self" \ "href"),
         find(invitation \ "_links" \ "agency" \ "href"),
@@ -80,7 +81,7 @@ class EmbeddedSection(embedded: JsLookupResult) {
   }
 }
 
-class LinkSection(links: JsLookupResult) {
+class LinkSection(links: JsValue) {
 
   def selfLink: String = (links \ "self" \ "href").as[String]
 

--- a/test/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsControllerSpec.scala
@@ -111,15 +111,5 @@ class ClientInvitationsControllerSpec extends AkkaMaterializerSpec with MockitoS
       ((jsonBodyOf(result) \ "_embedded" \ "invitations")(0) \ "id").asOpt[String] shouldBe None
       ((jsonBodyOf(result) \ "_embedded" \ "invitations")(0) \ "invitationId").asOpt[String] shouldBe None
     }
-
-    //TODO do we need this?
-//    "filter by status when a status is specified" in {
-//      whenAuthIsCalled.thenReturn(Future successful Accounts(None, Some(SaUtr(saUtr))))
-//      whenMtdClientIsLookedUp.thenReturn(Future successful Some(MtdClientId(clientId)))
-//
-//      when(invitationsService.list("mtd-sa", clientId, Some(Accepted))).thenReturn(Future successful ...)
-//
-//      ...
-//    }
   }
 }


### PR DESCRIPTION
Added a test to filter by client ID
Added an APIRequest trait to allow resource paths to be in one place
Moved older *ISpec tests to use new idioms