### PR TITLE
[FD][APB-431] Make sandbox routes accessible via the API platform

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/ApiPlatformRequestHandler.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/ApiPlatformRequestHandler.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation
+
+import javax.inject.Inject
+
+import play.api.http.{DefaultHttpRequestHandler, HttpConfiguration, HttpErrorHandler, HttpFilters}
+import play.api.mvc.RequestHeader
+import play.api.routing.Router
+
+/**
+ * Normalise the request path. The API platform strips the context
+ * '/agent-client-authorisation' from the URL before forwarding the request.
+ * Re-add it here if necessary.
+ */
+class ApiPlatformRequestHandler @Inject() (router: Router, errorHandler: HttpErrorHandler, configuration: HttpConfiguration, filters: HttpFilters)
+  extends DefaultHttpRequestHandler(router, errorHandler, configuration, filters) {
+
+  override def handlerForRequest(request: RequestHeader) = {
+    if (isApiPlatformRequest(request)) {
+      super.handlerForRequest(request.copy(path = "/agent-client-authorisation" + request.path ))
+    } else {
+      super.handlerForRequest(request)
+    }
+  }
+
+  private def isApiPlatformRequest(request: RequestHeader): Boolean =
+    request.path.startsWith("/sandbox") /* TODO we'll need something like the following to deal with non-sandbox requests
+    ||
+    request.path.startsWith("/agencies") ||
+    request.path.startsWith("/clients") ||
+    request.path == "/" */
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -20,22 +20,3 @@ GET      /clients/:clientId/invitations/received/:invitationId   @uk.gov.hmrc.ag
 
 # Whitelist
 GET      /forbidden                                     @uk.gov.hmrc.agentclientauthorisation.controllers.WhitelistController.forbidden
-
-# Sandbox Agent routes
-GET      /sandbox                                                       @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxRootController.getRootResource()
-GET      /sandbox/agencies                                              @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getDetailsForAuthenticatedAgency()
-GET      /sandbox/agencies/:arn                                         @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getDetailsForAgency(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn )
-GET      /sandbox/agencies/:arn/invitations                             @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getDetailsForAgency(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn )
-POST     /sandbox/agencies/:arn/invitations                             @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.createInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn)
-GET      /sandbox/agencies/:arn/invitations/sent                        @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getSentInvitations(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, regime: Option[String], clientId: Option[String], status: Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
-GET      /sandbox/agencies/:arn/invitations/sent/:invitation            @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getSentInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, invitation: String)
-PUT      /sandbox/agencies/:arn/invitations/sent/:invitation/cancel     @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.cancelInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, invitation: String)
-
-# Sandbox Client routes
-GET      /sandbox/clients                                               @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getDetailsForAuthenticatedClient()
-GET      /sandbox/clients/:clientId                                     @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getDetailsForClient(clientId: String)
-GET      /sandbox/clients/:clientId/invitations                         @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getDetailsForClient(clientId: String)
-PUT      /sandbox/clients/:clientId/invitations/received/:invitationId/accept  @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.acceptInvitation(clientId: String, invitationId: String)
-PUT      /sandbox/clients/:clientId/invitations/received/:invitationId/reject  @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.rejectInvitation(clientId: String, invitationId: String)
-GET      /sandbox/clients/:clientId/invitations/received                 @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getInvitations(clientId: String, status: Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
-GET      /sandbox/clients/:clientId/invitations/received/:invitationId   @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getInvitation(clientId: String, invitationId: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -21,6 +21,10 @@ play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
 play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
 play.modules.enabled += "uk.gov.hmrc.agentclientauthorisation.GuiceModule"
 
+# Global request handler
+# ~~~~
+play.http.requestHandler = "uk.gov.hmrc.agentclientauthorisation.ApiPlatformRequestHandler"
+
 
 # Session Timeout
 # ~~~~

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,6 @@
 # Add all the application routes to the app.routes file
 ->         /agent-client-authorisation    app.Routes
+->         /agent-client-authorisation/sandbox    sandbox.Routes
 ->         /                              health.Routes
 ->         /                              definition.Routes
 GET        /admin/metrics                 com.kenshoo.play.metrics.MetricsController.metrics

--- a/conf/sandbox.routes
+++ b/conf/sandbox.routes
@@ -1,0 +1,18 @@
+# Sandbox Agent routes
+GET      /                                                      @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxRootController.getRootResource()
+GET      /agencies                                              @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getDetailsForAuthenticatedAgency()
+GET      /agencies/:arn                                         @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getDetailsForAgency(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn )
+GET      /agencies/:arn/invitations                             @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getDetailsForAgency(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn )
+POST     /agencies/:arn/invitations                             @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.createInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn)
+GET      /agencies/:arn/invitations/sent                        @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getSentInvitations(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, regime: Option[String], clientId: Option[String], status: Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
+GET      /agencies/:arn/invitations/sent/:invitation            @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.getSentInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, invitation: String)
+PUT      /agencies/:arn/invitations/sent/:invitation/cancel     @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxAgencyInvitationsController.cancelInvitation(arn: uk.gov.hmrc.agentclientauthorisation.model.Arn, invitation: String)
+
+# Sandbox Client routes
+GET      /clients                                               @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getDetailsForAuthenticatedClient()
+GET      /clients/:clientId                                     @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getDetailsForClient(clientId: String)
+GET      /clients/:clientId/invitations                         @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getDetailsForClient(clientId: String)
+PUT      /clients/:clientId/invitations/received/:invitationId/accept  @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.acceptInvitation(clientId: String, invitationId: String)
+PUT      /clients/:clientId/invitations/received/:invitationId/reject  @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.rejectInvitation(clientId: String, invitationId: String)
+GET      /clients/:clientId/invitations/received                 @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getInvitations(clientId: String, status: Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
+GET      /clients/:clientId/invitations/received/:invitationId   @uk.gov.hmrc.agentclientauthorisation.controllers.sandbox.SandboxClientInvitationsController.getInvitation(clientId: String, invitationId: String)

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsISpec.scala
@@ -24,17 +24,16 @@ import org.scalatest.Inside
 import org.scalatest.concurrent.Eventually
 import play.api.libs.json.{JsArray, JsValue}
 import uk.gov.hmrc.agentclientauthorisation.model.Arn
-import uk.gov.hmrc.agentclientauthorisation.support.{MongoAppAndStubs, Resource, SecuredEndpointBehaviours}
+import uk.gov.hmrc.agentclientauthorisation.support.{APIRequests, MongoAppAndStubs, Resource, SecuredEndpointBehaviours}
 import uk.gov.hmrc.domain.AgentCode
 import uk.gov.hmrc.play.controllers.RestFormats
 import uk.gov.hmrc.play.test.UnitSpec
-import uk.gov.hmrc.agentclientauthorisation.support.APIRequests
 
 class SandboxAgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with SecuredEndpointBehaviours with Eventually with Inside with APIRequests {
   private val REGIME = "mtd-sa"
   private val agentCode = AgentCode("A12345A")
   private implicit val arn = Arn("ABCDEF12345678")
-  private val createInvitationUrl = s"/agent-client-authorisation/sandbox/agencies/${arn.arn}/invitations"
+  private val createInvitationUrl = s"/sandbox/agencies/${arn.arn}/invitations"
   private def getInvitationUrl = s"${agencyGetInvitationsUrl(arn)}/"
 
   override val sandboxMode = true
@@ -68,7 +67,7 @@ class SandboxAgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with 
       val response = responseForCreateInvitation()
 
       response.status shouldBe 201
-      response.header("location").get should startWith(agencyGetInvitationsUrl(arn))
+      response.header("location").get should startWith(externalUrl(agencyGetInvitationsUrl(arn)))
     }
   }
 
@@ -102,7 +101,7 @@ class SandboxAgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with 
       checkInvitation(invitations(1), testStartTime)
       invitations.map(selfLink) shouldBe invitationLinks
 
-      selfLink(response.json) shouldBe agencyGetInvitationsUrl(arn)
+      selfLink(response.json) shouldBe externalUrl(agencyGetInvitationsUrl(arn))
     }
   }
 
@@ -154,8 +153,8 @@ class SandboxAgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with 
       val response = new Resource(url, port).get()
 
       response.status shouldBe 200
-      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe url
-      (response.json \ "_links" \ "sent" \ "href").as[String] shouldBe agencyGetInvitationsUrl(arn)
+      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe externalUrl(url)
+      (response.json \ "_links" \ "sent" \ "href").as[String] shouldBe externalUrl(agencyGetInvitationsUrl(arn))
     }
   }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxClientInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxClientInvitationsISpec.scala
@@ -115,8 +115,8 @@ class SandboxClientInvitationsISpec extends UnitSpec with MongoAppAndStubs with 
       val response = new Resource(url, port).get()
 
       response.status shouldBe 200
-      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe url
-      (response.json \ "_links" \ "received" \ "href").as[String] shouldBe clientReceivedInvitationsUrl(mtdClientId)
+      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe externalUrl(url)
+      (response.json \ "_links" \ "received" \ "href").as[String] shouldBe externalUrl(clientReceivedInvitationsUrl(mtdClientId))
     }
    }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
@@ -26,7 +26,25 @@ trait APIRequests {
 
   def sandboxMode:Boolean = false
 
-  def baseUrl = if(sandboxMode) "/agent-client-authorisation/sandbox" else "/agent-client-authorisation"
+  def baseUrl = if(sandboxMode) "/sandbox" else "/agent-client-authorisation"
+
+  def externalUrl(serviceRouteUrl: String) =
+    if (sandboxMode) {
+      // TODO this is wrong - it should be the commented out version. However the plan is to get a release out where the API can be called in the sandbox first and fix the links it returns afterwards.
+//      "/agent-client-authorisation" + stripPrefix(serviceRouteUrl, "/sandbox")
+      "/agent-client-authorisation" + serviceRouteUrl
+    } else {
+      // non-sandbox routes can't currently be called by the API platform because they have the wrong URLs (the routes have a /agent-client-authorisation prefix which the API platform doesn't include in its requests' paths).
+      // That's why we don't do a translation here yet.
+      serviceRouteUrl
+    }
+
+
+  private def stripPrefix(s: String, prefix: String): String = {
+    if (!s.startsWith(prefix)) throw new IllegalArgumentException(s""""$s\" does not start with $prefix"""")
+    s.substring(prefix.length)
+  }
+
   def agenciesUrl = s"$baseUrl/agencies"
   def agencyUrl(arn: Arn) = s"$agenciesUrl/${arn.arn}"
   def agencyInvitationsUrl(arn: Arn) = s"${agencyUrl(arn)}/invitations"


### PR DESCRIPTION
i.e. accept sandbox requests without the /agent-client-authorisation path prefix because the API platform strips this context from the path when making requests to the backend service.