### PR TITLE
[FD][APB-431] Remove security checks from sandbox routes

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/HardCodedSandboxIds.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/HardCodedSandboxIds.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.controllers.sandbox
+
+import uk.gov.hmrc.agentclientauthorisation.model.{Arn, MtdClientId}
+
+object HardCodedSandboxIds {
+
+  val clientId = MtdClientId("MTD-REG-1234567890")
+
+  val arn = Arn("01234567-79ab-cdef-0123-456789abcdef")
+
+}

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsController.scala
@@ -16,47 +16,43 @@
 
 package uk.gov.hmrc.agentclientauthorisation.controllers.sandbox
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
 import org.joda.time.DateTime.now
+import play.api.mvc.Action
 import reactivemongo.bson.BSONObjectID
-import uk.gov.hmrc.agentclientauthorisation.connectors.{AgenciesFakeConnector, AuthConnector}
-import uk.gov.hmrc.agentclientauthorisation.controllers.actions.AuthActions
 import uk.gov.hmrc.agentclientauthorisation.controllers.{AgencyInvitationsHal, HalWriter, ReverseAgencyInvitationsRoutes, SUPPORTED_REGIME}
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 @Singleton
-class SandboxAgencyInvitationsController @Inject() (
-  override val authConnector: AuthConnector,
-  override val agenciesFakeConnector: AgenciesFakeConnector
-) extends BaseController with AuthActions with HalWriter with AgencyInvitationsHal {
+class SandboxAgencyInvitationsController extends BaseController with HalWriter with AgencyInvitationsHal {
 
-  def createInvitation(arn: Arn) = onlyForSaAgents { implicit request =>
-      Created.withHeaders(location(arn, "invitationId"))
+  def createInvitation(arn: Arn) = Action { implicit request =>
+    Created.withHeaders(location(arn, "invitationId"))
   }
 
   private def location(arn: Arn, invitationId: String) = {
     LOCATION -> routes.SandboxAgencyInvitationsController.getSentInvitation(arn, invitationId).url
   }
 
-  def getSentInvitations(arn: Arn, regime: Option[String], clientId: Option[String], status: Option[InvitationStatus]) = onlyForSaAgents { implicit request =>
+  def getSentInvitations(arn: Arn, regime: Option[String], clientId: Option[String], status: Option[InvitationStatus]) = Action { implicit request =>
     Ok(toHalResource(List(invitation(arn), invitation(arn)), arn, regime, clientId, status))
   }
 
-  def getDetailsForAuthenticatedAgency() = onlyForSaAgents { implicit request =>
-    Ok(toHalResource(request.arn, request.path))
+  def getDetailsForAuthenticatedAgency() = Action { implicit request =>
+    Ok(toHalResource(HardCodedSandboxIds.arn, request.path))
   }
 
-  def getDetailsForAgency(arn: Arn) = onlyForSaAgents { implicit request =>
+  def getDetailsForAgency(arn: Arn) = Action { implicit request =>
     Ok(toHalResource(arn, request.path))
   }
 
-  def getSentInvitation(arn: Arn, invitationId: String) = onlyForSaAgents { implicit request =>
+  def getSentInvitation(arn: Arn, invitationId: String) = Action { implicit request =>
     Ok(toHalResource(invitation(arn)))
   }
 
-  def cancelInvitation(arn: Arn, invitation: String) = onlyForSaAgents { implicit request =>
+  def cancelInvitation(arn: Arn, invitation: String) = Action { implicit request =>
     NoContent
   }
 

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxClientInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxClientInvitationsController.scala
@@ -16,44 +16,39 @@
 
 package uk.gov.hmrc.agentclientauthorisation.controllers.sandbox
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
 import org.joda.time.DateTime.now
-import play.api.mvc.Call
+import play.api.mvc.{Action, Call}
 import reactivemongo.bson.BSONObjectID
-import uk.gov.hmrc.agentclientauthorisation.connectors.{AgenciesFakeConnector, AuthConnector}
-import uk.gov.hmrc.agentclientauthorisation.controllers.actions.AuthActions
 import uk.gov.hmrc.agentclientauthorisation.controllers.{ClientInvitationsHal, HalWriter, ReverseClientInvitationsRoutes, SUPPORTED_REGIME}
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 @Singleton
-class SandboxClientInvitationsController @Inject() (
-  override val authConnector: AuthConnector,
-  override val agenciesFakeConnector: AgenciesFakeConnector
-) extends BaseController with AuthActions with HalWriter with ClientInvitationsHal {
+class SandboxClientInvitationsController extends BaseController with HalWriter with ClientInvitationsHal {
 
-   def getDetailsForAuthenticatedClient() = onlyForSaClients { implicit request =>
-    Ok(toHalResource(request.mtdClientId.value, request.path))
+  def getDetailsForAuthenticatedClient() = Action { implicit request =>
+    Ok(toHalResource(HardCodedSandboxIds.clientId.value, request.path))
   }
 
-  def getDetailsForClient(clientId: String) = onlyForSaClients { implicit request =>
+  def getDetailsForClient(clientId: String) = Action { implicit request =>
     Ok(toHalResource(clientId, request.path))
   }
 
-  def acceptInvitation(clientId: String, invitationId: String) = onlyForSaClients { implicit request =>
+  def acceptInvitation(clientId: String, invitationId: String) = Action { implicit request =>
     NoContent
   }
 
-  def rejectInvitation(clientId: String, invitationId: String) = onlyForSaClients { implicit request =>
+  def rejectInvitation(clientId: String, invitationId: String) = Action { implicit request =>
     NoContent
   }
 
-  def getInvitation(clientId: String, invitationId: String) = onlyForSaClients { implicit request =>
+  def getInvitation(clientId: String, invitationId: String) = Action { implicit request =>
     Ok(toHalResource(invitation(clientId)))
   }
 
-  def getInvitations(clientId: String, status: Option[InvitationStatus]) = onlyForSaClients { implicit request =>
+  def getInvitations(clientId: String, status: Option[InvitationStatus]) = Action { implicit request =>
     Ok(toHalResource(Seq(invitation(clientId), invitation(clientId)), clientId, status))
   }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxClientInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxClientInvitationsISpec.scala
@@ -72,7 +72,7 @@ class SandboxClientInvitationsISpec extends UnitSpec with MongoAppAndStubs with 
 
     "return a 204 response code" in {
       given().client(clientId = mtdClientId).isLoggedIn()
-      val response = clientAcceptInvitation(mtdClientId, "invitationId")
+      val response = clientRejectInvitation(mtdClientId, "invitationId")
       response.status shouldBe 204
     }
   }


### PR DESCRIPTION
The sandbox uses a test user that doesn't pass the security checks, so without this change the routes always returned a 401 when called in sandbox mode.

Because we aren't checking whether the user is a SA client or agent we can't use obtain the current user's identifiers any more and instead have to use hardcoded IDs when the response contains an identifier for the logged in user.