### PR TITLE
[FD][APB-434] Make non-sandbox routes accessible via the API platform

### DIFF
--- a/it/uk/gov/hmrc/agentclientauthorisation/AgencyInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/AgencyInvitationsISpec.scala
@@ -24,7 +24,6 @@ import uk.gov.hmrc.agentclientauthorisation.support._
 import uk.gov.hmrc.domain.AgentCode
 import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 import uk.gov.hmrc.play.test.UnitSpec
-import uk.gov.hmrc.play.http.HttpResponse
 
 class AgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with Inspectors with Inside with Eventually with SecuredEndpointBehaviours with APIRequests {
 
@@ -142,8 +141,8 @@ class AgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with Inspect
       val response = new Resource(url, port).get()
 
       response.status shouldBe 200
-      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe url
-      (response.json \ "_links" \ "sent" \ "href").as[String] shouldBe agencyGetInvitationsUrl(arn)
+      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe externalUrl(url)
+      (response.json \ "_links" \ "sent" \ "href").as[String] shouldBe externalUrl(agencyGetInvitationsUrl(arn))
     }
   }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/ClientInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/ClientInvitationsISpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.concurrent.Eventually
 import uk.gov.hmrc.agentclientauthorisation.model.Arn
 import uk.gov.hmrc.agentclientauthorisation.support._
 import uk.gov.hmrc.domain.AgentCode
-import uk.gov.hmrc.play.auth.microservice.connectors.Regime
 import uk.gov.hmrc.play.test.UnitSpec
 
 class ClientInvitationsISpec extends UnitSpec with MongoAppAndStubs with SecuredEndpointBehaviours with Eventually with Inside with APIRequests {
@@ -109,8 +108,8 @@ class ClientInvitationsISpec extends UnitSpec with MongoAppAndStubs with Secured
       val response = new Resource(url, port).get()
 
       response.status shouldBe 200
-      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe url
-      (response.json \ "_links" \ "received" \ "href").as[String] shouldBe invitationsReceivedUrl
+      (response.json \ "_links" \ "self" \ "href").as[String] shouldBe externalUrl(url)
+      (response.json \ "_links" \ "received" \ "href").as[String] shouldBe externalUrl(invitationsReceivedUrl)
     }
   }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/APIRequests.scala
@@ -26,7 +26,7 @@ trait APIRequests {
 
   def sandboxMode:Boolean = false
 
-  def baseUrl = if(sandboxMode) "/sandbox" else "/agent-client-authorisation"
+  def baseUrl = if(sandboxMode) "/sandbox" else ""
 
   def externalUrl(serviceRouteUrl: String) =
     if (sandboxMode) {
@@ -34,9 +34,7 @@ trait APIRequests {
 //      "/agent-client-authorisation" + stripPrefix(serviceRouteUrl, "/sandbox")
       "/agent-client-authorisation" + serviceRouteUrl
     } else {
-      // non-sandbox routes can't currently be called by the API platform because they have the wrong URLs (the routes have a /agent-client-authorisation prefix which the API platform doesn't include in its requests' paths).
-      // That's why we don't do a translation here yet.
-      serviceRouteUrl
+      "/agent-client-authorisation" + serviceRouteUrl
     }
 
 


### PR DESCRIPTION
i.e. accept sandbox requests without the /agent-client-authorisation path prefix because the API platform strips this context from the path when making requests to the backend service.