### PR TITLE
[FD] Rename "invitation" link to "invitations" and use a consistent name for the API

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsHal.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsHal.scala
@@ -39,7 +39,7 @@ trait AgencyInvitationsHal {
   }
 
   private def invitationLinks(invitations: List[Invitation]): Vector[HalLink] = {
-    invitations.map { i => HalLink("invitation", routes.AgencyInvitationsController.getSentInvitation(i.arn, i.id.stringify).toString)}.toVector
+    invitations.map { i => HalLink("invitations", routes.AgencyInvitationsController.getSentInvitation(i.arn, i.id.stringify).toString)}.toVector
   }
 
   def toHalResource(invitation: Invitation): HalResource = {

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsHal.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsHal.scala
@@ -39,7 +39,7 @@ trait ClientInvitationsHal {
   }
 
   private def invitationLinks(invitations: Seq[Invitation]): Vector[HalLink] = {
-    invitations.map { i => HalLink("invitation", routes.ClientInvitationsController.getInvitation(i.clientId, i.id.stringify).toString)}.toVector
+    invitations.map { i => HalLink("invitations", routes.ClientInvitationsController.getInvitation(i.clientId, i.id.stringify).toString)}.toVector
   }
 
   def toHalResource(clientId: String, selfLinkHref: String): HalResource = {

--- a/app/uk/gov/hmrc/agentclientauthorisation/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/agentclientauthorisation/views/definition.scala.txt
@@ -22,7 +22,7 @@
   }],
 
   "api": {
-    "name": "Agent-client Authorisation",
+    "name": "Agent Client Authorisation",
     "description": "An API for agents and clients akin to the paper 64-8 form.  The production version of this API is not yet available, only the test version which should be accessed using your test credentials.",
     "context": "agent-client-authorisation",
     "versions": [{

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/api/ApiPlatformISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/api/ApiPlatformISpec.scala
@@ -32,8 +32,7 @@ class ApiPlatformISpec extends UnitSpec with MongoAppAndStubs {
 
       val definition = response.json
 
-      (definition \ "api" \ "name").as[String] shouldBe "Agent-client Authorisation"
-      (definition \ "api" \ "name").as[String] shouldBe "Agent-client Authorisation"
+      (definition \ "api" \ "name").as[String] shouldBe "Agent Client Authorisation"
 
       val accessConfig = definition \ "api" \ "versions" \\ "access"
       (accessConfig.head \ "type").as[String] shouldBe "PRIVATE"

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsISpec.scala
@@ -77,7 +77,7 @@ class SandboxAgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with 
 
       response.status shouldBe 200
       val invitations = (response.json \ "_embedded" \ "invitations").as[JsArray].value
-      val invitationLinks = (response.json \ "_links" \ "invitation" \\ "href").map(_.as[String])
+      val invitationLinks = (response.json \ "_links" \ "invitations" \\ "href").map(_.as[String])
 
       invitations.size shouldBe 2
       checkInvitation(invitations.head, testStartTime)

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/halTestHelpers.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/halTestHelpers.scala
@@ -85,5 +85,5 @@ class LinkSection(links: JsValue) {
 
   def selfLink: String = (links \ "self" \ "href").as[String]
 
-  def invitations: Seq[String] = (links \ "invitation" \\ "href").map(_.as[String])
+  def invitations: Seq[String] = (links \ "invitations" \\ "href").map(_.as[String])
 }

--- a/resources/public/api/conf/0.0/examples/get-agency-invitations-sent-example.json
+++ b/resources/public/api/conf/0.0/examples/get-agency-invitations-sent-example.json
@@ -3,7 +3,7 @@
     "self": {
       "href": "/agent-client-authorisation/agencies/AARN9999999/invitations/sent"
     },
-    "invitation": [
+    "invitations": [
       {
         "href": "/agent-client-authorisation/agencies/AARN9999999/invitations/sent/5888c22e11000011007afc11"
       },

--- a/resources/public/api/conf/0.0/examples/get-client-invitations-received-example.json
+++ b/resources/public/api/conf/0.0/examples/get-client-invitations-received-example.json
@@ -3,7 +3,7 @@
     "self": {
       "href": "/agent-client-authorisation/clients/client123/invitations/received"
     },
-    "invitation": [
+    "invitations": [
       {
         "href": "/agent-client-authorisation/clients/client123/invitations/received/5889f19c5200005200ed1efc"
       },

--- a/resources/public/api/conf/0.0/schemas/invitations.json
+++ b/resources/public/api/conf/0.0/schemas/invitations.json
@@ -17,7 +17,7 @@
             "href"
           ]
         },
-        "invitation": {
+        "invitations": {
           "type": "array",
           "items": {
             "type": "object",
@@ -35,7 +35,7 @@
       },
       "required": [
         "self",
-        "invitation"
+        "invitations"
       ]
     },
     "_embedded": {


### PR DESCRIPTION
Conceptually the links are links to the embedded resources, so the _links entry and the _embedded entries should have the same name.