### PR TITLE
[APB-797][RV,AO] remove audit event AgentClientInvitationResponse

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/audit/AuditService.scala
@@ -39,17 +39,6 @@ object AgentClientInvitationEvent extends Enumeration {
 @Singleton
 class AuditService @Inject()(val auditConnector: AuditConnector) {
 
-  def sendAgentInvitationResponse(invitationId: String, arn: Arn, invitationStatus: InvitationStatus, mtdItId: MtdItId)
-                                 (implicit hc: HeaderCarrier, request: Request[Any]): Unit = {
-    auditEvent(AgentClientInvitationEvent.AgentClientInvitationResponse, "agent-client-invitation-response",
-      Seq(
-        "invitationId" -> invitationId,
-        "agentReferenceNumber" -> arn.value,
-        "regimeId" -> mtdItId.value,
-        "regime" -> "HMRC-MTD-IT",
-        "clientResponse" -> invitationStatus.toString))
-  }
-
   def sendAgentClientRelationshipCreated(invitationId: String, arn: Arn, mtdItId: MtdItId)
                                  (implicit hc: HeaderCarrier, request: Request[Any]): Unit = {
     auditEvent(AgentClientInvitationEvent.AgentClientRelationshipCreated, "agent-client-relationship-created",

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsController.scala
@@ -77,9 +77,7 @@ class ClientInvitationsController @Inject()(invitationsService: InvitationsServi
       case Some(invitation)
         if invitation.clientId == mtdItId.value =>
         action(invitation) map {
-          case Right(invite) =>
-            auditService.sendAgentInvitationResponse(invite.id.stringify, invite.arn, invite.status, mtdItId)
-            NoContent
+          case Right(_) => NoContent
           case Left(message) => invalidInvitationStatus(message)
         }
       case None => Future successful InvitationNotFound

--- a/test/uk/gov/hmrc/agentclientauthorisation/audit/AuditSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/audit/AuditSpec.scala
@@ -36,49 +36,6 @@ import scala.concurrent.ExecutionContext
 class AuditSpec extends UnitSpec with MockitoSugar with Eventually {
 
   "auditEvent" should {
-    "send an AgentClientInvitationResponse Event" in {
-      val mockConnector = mock[AuditConnector]
-      val service = new AuditService(mockConnector)
-
-      val hc = HeaderCarrier(
-        authorization = Some(Authorization("dummy bearer token")),
-        sessionId = Some(SessionId("dummy session id")),
-        requestId = Some(RequestId("dummy request id")))
-
-      val arn: Arn = Arn("HX2345")
-      val inviteStatus = InvitationStatus("accepted")
-      val invitationId: String = "1"
-
-      await(service.sendAgentInvitationResponse(
-        invitationId,
-        arn,
-        inviteStatus,
-        mtdItId1)(
-        hc,
-        FakeRequest("GET", "/path")))
-
-      eventually {
-        val captor = ArgumentCaptor.forClass(classOf[DataEvent])
-        verify(mockConnector).sendEvent(captor.capture())(any[HeaderCarrier], any[ExecutionContext])
-        val sentEvent = captor.getValue.asInstanceOf[DataEvent]
-
-        sentEvent.auditType shouldBe "AgentClientInvitationResponse"
-        sentEvent.auditSource shouldBe "agent-client-authorisation"
-        sentEvent.detail("clientResponse") shouldBe "Accepted"
-        sentEvent.detail("invitationId") shouldBe "1"
-        sentEvent.detail("agentReferenceNumber") shouldBe "HX2345"
-        sentEvent.detail("regimeId") shouldBe "mtdItId"
-        sentEvent.detail("regime") shouldBe "HMRC-MTD-IT"
-
-        sentEvent.tags.contains("Authorization") shouldBe false
-        sentEvent.detail("Authorization") shouldBe "dummy bearer token"
-
-        sentEvent.tags("transactionName") shouldBe "agent-client-invitation-response"
-        sentEvent.tags("path") shouldBe "/path"
-        sentEvent.tags("X-Session-ID") shouldBe "dummy session id"
-        sentEvent.tags("X-Request-ID") shouldBe "dummy request id"
-      }
-    }
 
     "send an AgentClientRelationshipCreated Event" in {
       val mockConnector = mock[AuditConnector]

--- a/test/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsControllerSpec.scala
@@ -71,7 +71,7 @@ class ClientInvitationsControllerSpec extends AkkaMaterializerSpec with Resettin
 
       val response = await(controller.acceptInvitation(mtdItId1, invitationId)(FakeRequest()))
       response.header.status shouldBe 204
-      verifyAuditEvents()
+      verifyAgentClientRelationshipCreatedAuditEvent()
     }
 
     "Return not found when the invitation doesn't exist" in {
@@ -129,7 +129,6 @@ class ClientInvitationsControllerSpec extends AkkaMaterializerSpec with Resettin
       val response = await(controller.rejectInvitation(mtdItId1, invitationId)(FakeRequest()))
 
       response.header.status shouldBe 204
-      verifyInvitationResponseAuditEvent()
     }
 
     "Return not found when the invitation doesn't exist" in {
@@ -140,7 +139,6 @@ class ClientInvitationsControllerSpec extends AkkaMaterializerSpec with Resettin
       val response = await(controller.rejectInvitation(mtdItId1, invitationId)(FakeRequest()))
 
       response shouldBe InvitationNotFound
-      verifyNoAuditEventSent()
     }
 
     "the invitation cannot be actioned" in {
@@ -152,7 +150,6 @@ class ClientInvitationsControllerSpec extends AkkaMaterializerSpec with Resettin
       val response = await(controller.rejectInvitation(mtdItId1, invitationId)(FakeRequest()))
 
       response shouldBe invalidInvitationStatus("failure message")
-      verifyNoAuditEventSent()
     }
 
     "Return NoPermissionOnClient when given mtdItId does not match authMtdItId" in {
@@ -161,7 +158,6 @@ class ClientInvitationsControllerSpec extends AkkaMaterializerSpec with Resettin
       val response = await(controller.rejectInvitation(MtdItId("invalid"), invitationId)(FakeRequest()))
 
       response shouldBe NoPermissionOnClient
-      verifyNoAuditEventSent()
     }
 
     "Return unauthorised when the user is not logged in to MDTP" in {
@@ -170,7 +166,6 @@ class ClientInvitationsControllerSpec extends AkkaMaterializerSpec with Resettin
       val response = await(controller.rejectInvitation(mtdItId1, invitationId)(FakeRequest()))
 
       response shouldBe GenericUnauthorized
-      verifyNoAuditEventSent()
     }
   }
 

--- a/test/uk/gov/hmrc/agentclientauthorisation/support/ClientEndpointBehaviours.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/support/ClientEndpointBehaviours.scala
@@ -80,17 +80,6 @@ trait ClientEndpointBehaviours extends TransitionInvitation with Eventually {
   def whenClientReceivedInvitation: OngoingStubbing[Future[Seq[Invitation]]] =
     when(invitationsService.clientsReceived(eqs("HMRC-MTD-IT"), eqs(mtdItId1), eqs(None))(any()))
 
-  def assertInvitationResponseEvent(event: DataEvent) = {
-    event.auditSource shouldBe "agent-client-authorisation"
-    event.auditType shouldBe "AgentClientInvitationResponse"
-    val details = event.detail.toSeq
-    details should contain allOf(
-      "invitationId" -> invitationId,
-      "agentReferenceNumber" -> arn.value,
-      "regimeId" -> mtdItId1.value,
-      "regime" -> "HMRC-MTD-IT")
-  }
-
   def assertCreateRelationshipEvent(event: DataEvent) = {
     event.auditSource shouldBe "agent-client-authorisation"
     event.auditType shouldBe "AgentClientRelationshipCreated"
@@ -102,34 +91,12 @@ trait ClientEndpointBehaviours extends TransitionInvitation with Eventually {
       "regime" -> "HMRC-MTD-IT")
   }
 
-  def verifyInvitationResponseAuditEvent() = {
-    eventually {
-      val argumentCaptor: ArgumentCaptor[DataEvent] = ArgumentCaptor.forClass(classOf[DataEvent])
-      verify(auditConnector).sendEvent(argumentCaptor.capture())(any(), any())
-      val event: DataEvent = argumentCaptor.getValue
-      assertInvitationResponseEvent(event)
-    }
-  }
-
   def verifyAgentClientRelationshipCreatedAuditEvent() = {
     eventually {
       val argumentCaptor: ArgumentCaptor[DataEvent] = ArgumentCaptor.forClass(classOf[DataEvent])
       verify(auditConnector).sendEvent(argumentCaptor.capture())(any(), any())
       val event: DataEvent = argumentCaptor.getValue
       assertCreateRelationshipEvent(event)
-    }
-  }
-
-  import scala.collection.JavaConverters._
-
-  def verifyAuditEvents() = {
-    eventually {
-      val argumentCaptor: ArgumentCaptor[DataEvent] = ArgumentCaptor.forClass(classOf[DataEvent])
-      verify(auditConnector, times(2)).sendEvent(argumentCaptor.capture())(any(), any())
-      val events: Seq[DataEvent] = argumentCaptor.getAllValues.asScala
-      assertCreateRelationshipEvent(events(0))
-      assertInvitationResponseEvent(events(1))
-
     }
   }
 


### PR DESCRIPTION
which has been moved to agent-invitations-frontend