### PR TITLE
Apb 1865 - Add 'use by' date to 'invitation complete' page

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/audit/AuditService.scala
@@ -20,7 +20,8 @@ import javax.inject.{Inject, Singleton}
 
 import play.api.mvc.Request
 import uk.gov.hmrc.agentclientauthorisation.audit.AgentClientInvitationEvent.AgentClientInvitationEvent
-import uk.gov.hmrc.agentclientauthorisation.model.{ClientId, Invitation, Service}
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier.ClientId
+import uk.gov.hmrc.agentclientauthorisation.model.{Invitation, Service}
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions._
@@ -39,7 +40,7 @@ object AgentClientInvitationEvent extends Enumeration {
 @Singleton
 class AuditService @Inject()(val auditConnector: AuditConnector) {
 
-  def sendAgentClientRelationshipCreated(invitationId: String, arn: Arn, clientId: ClientId[_], service: Service)
+  def sendAgentClientRelationshipCreated(invitationId: String, arn: Arn, clientId: ClientId, service: Service)
                                  (implicit hc: HeaderCarrier, request: Request[Any]): Unit = {
     auditEvent(AgentClientInvitationEvent.AgentClientRelationshipCreated, "agent-client-relationship-created",
       Seq(

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/AuthConnector.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/AuthConnector.scala
@@ -26,7 +26,7 @@ import play.api.mvc._
 import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
 import uk.gov.hmrc.agentclientauthorisation._
 import uk.gov.hmrc.agentclientauthorisation.controllers.ErrorResults._
-import uk.gov.hmrc.agentclientauthorisation.model.{ClientId, Service}
+import uk.gov.hmrc.agentclientauthorisation.model.{ClientIdentifier, Service}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId}
 import uk.gov.hmrc.auth.core
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
@@ -82,13 +82,13 @@ class AuthConnector @Inject()(metrics: Metrics,
   private def isAgent(group: AffinityGroup): Boolean = group.toString.contains("Agent")
 
   def onlyForClients[T<:TaxIdentifier](service: Service, enrolmentId: String)
-                    (action: Request[AnyContent] => ClientId[T] => Future[Result])
+                    (action: Request[AnyContent] => ClientIdentifier[T] => Future[Result])
                     (taxId: (String) => T): Action[AnyContent] = Action.async {
     implicit request =>
       authorised(AuthProvider).retrieve(allEnrolments) {
         allEnrols =>
           val clientId = extractEnrolmentData(allEnrols.enrolments, service.enrolmentKey, enrolmentId)
-          if (clientId.isDefined) action(request)(ClientId(taxId(clientId.get)))
+          if (clientId.isDefined) action(request)(ClientIdentifier(taxId(clientId.get)))
           else Future successful ClientNinoNotFound
       } recover {
         case _ => GenericUnauthorized

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/RelationshipsConnector.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/RelationshipsConnector.scala
@@ -43,12 +43,12 @@ class RelationshipsConnector @Inject() (@Named("relationships-baseUrl") baseUrl:
   }
 
   private def relationshipUrl(invitation: Invitation): URL = new URL(baseUrl,
-    s"/agent-client-relationships/agent/${encodePathSegment(invitation.arn.value)}/service/HMRC-MTD-IT/client/MTDITID/${encodePathSegment(invitation.clientId)}")
+    s"/agent-client-relationships/agent/${encodePathSegment(invitation.arn.value)}/service/HMRC-MTD-IT/client/MTDITID/${encodePathSegment(invitation.clientId.value)}")
 
   private def afiRelationshipUrl(invitation: Invitation): URL = {
     val arn = encodePathSegment(invitation.arn.value)
     val service = encodePathSegment(invitation.service.id)
-    val clientId = encodePathSegment(invitation.clientId)
+    val clientId = encodePathSegment(invitation.clientId.value)
     new URL(afiBaseUrl, s"/agent-fi-relationship/relationships/agent/$arn/service/$service/client/$clientId")
   }
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsController.scala
@@ -72,9 +72,10 @@ class AgencyInvitationsController @Inject()(override val postcodeService: Postco
       case None => Future successful
         BadRequest(s"invalid combination of client id ${agentInvitation.clientId} and client id type ${agentInvitation.clientIdType}")
       case Some(taxId) =>
-        invitationsService.create(
-          arn, service, ClientId(taxId), agentInvitation.clientPostcode, agentInvitation.clientId, agentInvitation.clientIdType).map(
-          invitation => Created.withHeaders(location(invitation)))
+        val suppliedClientId = ClientIdentifier(agentInvitation.clientId, agentInvitation.clientIdType)
+        invitationsService.create(arn, service, ClientIdentifier(taxId), agentInvitation.clientPostcode, suppliedClientId).map(
+          invitation => Created.withHeaders(location(invitation))
+        )
     }
   }
 

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/BaseClientInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/BaseClientInvitationsController.scala
@@ -58,7 +58,7 @@ abstract class BaseClientInvitationsController[T <: TaxIdentifier](invitationsSe
 
     forThisClient(clientId) {
       invitationsService.findInvitation(invitationId).map {
-        case Some(x) if x.clientId == clientId.value => Ok(toHalResource(x))
+        case Some(x) if x.clientId == clientId => Ok(toHalResource(x))
         case None => InvitationNotFound
         case _ => NoPermissionOnClient
       }

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsHal.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientInvitationsHal.scala
@@ -20,9 +20,10 @@ import play.api.hal.Hal.hal
 import play.api.hal.{HalLink, HalLinks, HalResource}
 import play.api.libs.json.Json._
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.domain.{Nino, TaxIdentifier}
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier.ClientId
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentmtdidentifiers.model.MtdItId
+import uk.gov.hmrc.domain.Nino
 
 trait ClientInvitationsHal {
 
@@ -30,20 +31,20 @@ trait ClientInvitationsHal {
 
   def toHalResource(invitation: Invitation): HalResource = {
     val link = invitation.service match {
-      case Service.MtdIt => routes.MtdItClientInvitationsController.getInvitation(MtdItId(invitation.clientId), invitation.invitationId)
-      case Service.PersonalIncomeRecord  => routes.NiClientInvitationsController.getInvitation(Nino(invitation.clientId), invitation.invitationId)
+      case Service.MtdIt => routes.MtdItClientInvitationsController.getInvitation(MtdItId(invitation.clientId.value), invitation.invitationId)
+      case Service.PersonalIncomeRecord  => routes.NiClientInvitationsController.getInvitation(Nino(invitation.clientId.value), invitation.invitationId)
     }
     var links = HalLinks(Vector(HalLink("self", link.url)))
 
     agencyLink(invitation).foreach(href => links = links ++ HalLink("agency", href))
 
     val acceptLink = invitation.service match {
-        case Service.MtdIt => routes.MtdItClientInvitationsController.acceptInvitation(MtdItId(invitation.clientId), invitation.invitationId)
-        case Service.PersonalIncomeRecord => routes.NiClientInvitationsController.acceptInvitation(Nino(invitation.clientId), invitation.invitationId)
+        case Service.MtdIt => routes.MtdItClientInvitationsController.acceptInvitation(MtdItId(invitation.clientId.value), invitation.invitationId)
+        case Service.PersonalIncomeRecord => routes.NiClientInvitationsController.acceptInvitation(Nino(invitation.clientId.value), invitation.invitationId)
     }
     val rejectLink = invitation.service match {
-      case Service.MtdIt => routes.MtdItClientInvitationsController.rejectInvitation(MtdItId(invitation.clientId), invitation.invitationId)
-      case Service.PersonalIncomeRecord => routes.NiClientInvitationsController.rejectInvitation(Nino(invitation.clientId), invitation.invitationId)
+      case Service.MtdIt => routes.MtdItClientInvitationsController.rejectInvitation(MtdItId(invitation.clientId.value), invitation.invitationId)
+      case Service.PersonalIncomeRecord => routes.NiClientInvitationsController.rejectInvitation(Nino(invitation.clientId.value), invitation.invitationId)
     }
 
     if (invitation.status == Pending) {
@@ -57,28 +58,28 @@ trait ClientInvitationsHal {
   private def invitationLinks(invitations: Seq[Invitation]): Vector[HalLink] = {
     invitations.map { i =>
       val link = i.service match {
-        case Service.MtdIt => routes.MtdItClientInvitationsController.getInvitation(MtdItId(i.clientId), i.invitationId)
-        case Service.PersonalIncomeRecord => routes.NiClientInvitationsController.getInvitation(Nino(i.clientId), i.invitationId)
+        case Service.MtdIt => routes.MtdItClientInvitationsController.getInvitation(MtdItId(i.clientId.value), i.invitationId)
+        case Service.PersonalIncomeRecord => routes.NiClientInvitationsController.getInvitation(Nino(i.clientId.value), i.invitationId)
       }
       HalLink("invitations", link.toString)
     }.toVector
   }
 
-  def toHalResource(clientId: ClientId[_], selfLinkHref: String): HalResource = {
+  def toHalResource(clientId: ClientId, selfLinkHref: String): HalResource = {
     val selfLink = Vector(HalLink("self", selfLinkHref))
     val link = clientId match {
-      case clientId @ ClientId(MtdItId(_)) => routes.MtdItClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[MtdItId], None)
-      case clientId @ ClientId(Nino(_)) => routes.NiClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[Nino], None)
+      case clientId @ ClientIdentifier(MtdItId(_)) => routes.MtdItClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[MtdItId], None)
+      case clientId @ ClientIdentifier(Nino(_)) => routes.NiClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[Nino], None)
     }
     hal(Json.obj(), selfLink ++ Vector(HalLink("received", link.url)), Vector())
   }
 
-  def toHalResource(invitations: Seq[Invitation], clientId: ClientId[_ <: TaxIdentifier], status: Option[InvitationStatus]): HalResource = {
+  def toHalResource(invitations: Seq[Invitation], clientId: ClientId , status: Option[InvitationStatus]): HalResource = {
     val requestResources: Vector[HalResource] = invitations.map(invitation => toHalResource(invitation)).toVector
 
     val link = clientId match {
-      case clientId @ ClientId(MtdItId(_)) => routes.MtdItClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[MtdItId], None)
-      case clientId @ ClientId(Nino(_)) => routes.NiClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[Nino], None)
+      case clientId @ ClientIdentifier(MtdItId(_)) => routes.MtdItClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[MtdItId], None)
+      case clientId @ ClientIdentifier(Nino(_)) => routes.NiClientInvitationsController.getInvitations(clientId.underlying.asInstanceOf[Nino], None)
     }
 
     val links = Vector(HalLink("self", link.url)) ++ invitationLinks(invitations)

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/MtdItClientInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/MtdItClientInvitationsController.scala
@@ -67,6 +67,6 @@ class MtdItClientInvitationsController @Inject()(invitationsService: Invitations
   }
 
   def onlyForClients(action: Request[AnyContent] => ClientIdentifier[MtdItId] => Future[Result]): Action[AnyContent] =
-    super.onlyForClients(Service.MtdIt, MtdItIdType.enrolmentId)(action)(MtdItId.apply)
+    super.onlyForClients(Service.MtdIt, MtdItIdType)(action)
 
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/MtdItClientInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/MtdItClientInvitationsController.scala
@@ -22,7 +22,7 @@ import com.kenshoo.play.metrics.Metrics
 import play.api.mvc.{Action, AnyContent, Request, Result}
 import uk.gov.hmrc.agentclientauthorisation._
 import uk.gov.hmrc.agentclientauthorisation.audit.AuditService
-import uk.gov.hmrc.agentclientauthorisation.model.{ClientId, InvitationStatus, MtdItIdType, Service}
+import uk.gov.hmrc.agentclientauthorisation.model.{ClientIdentifier, InvitationStatus, MtdItIdType, Service}
 import uk.gov.hmrc.agentclientauthorisation.service.InvitationsService
 import uk.gov.hmrc.agentmtdidentifiers.model.{InvitationId, MtdItId}
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
@@ -40,33 +40,33 @@ class MtdItClientInvitationsController @Inject()(invitationsService: Invitations
 
   def getDetailsForClient(mtdItId: MtdItId): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authMtdItId => getDetailsForClient(ClientId(mtdItId), request)
+      implicit authMtdItId => getDetailsForClient(ClientIdentifier(mtdItId), request)
   }
 
   def acceptInvitation(mtdItId: MtdItId, invitationId: InvitationId): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authMtdItId => acceptInvitation(ClientId(mtdItId), invitationId)
+      implicit authMtdItId => acceptInvitation(ClientIdentifier(mtdItId), invitationId)
   }
 
   def rejectInvitation(mtdItId: MtdItId, invitationId: InvitationId): Action[AnyContent] = onlyForClients {
     implicit request =>
       implicit authMtdItId =>
-        forThisClient(ClientId(mtdItId)) {
-          actionInvitation(ClientId(mtdItId), invitationId, invitationsService.rejectInvitation)
+        forThisClient(ClientIdentifier(mtdItId)) {
+          actionInvitation(ClientIdentifier(mtdItId), invitationId, invitationsService.rejectInvitation)
         }
   }
 
   def getInvitation(mtdItId: MtdItId, invitationId: InvitationId): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authMtdItId => getInvitation(ClientId(mtdItId), invitationId)
+      implicit authMtdItId => getInvitation(ClientIdentifier(mtdItId), invitationId)
   }
 
   def getInvitations(mtdItId: MtdItId, status: Option[InvitationStatus]): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authMtdItId => getInvitations(ClientId(mtdItId), status)
+      implicit authMtdItId => getInvitations(ClientIdentifier(mtdItId), status)
   }
 
-  def onlyForClients(action: Request[AnyContent] => ClientId[MtdItId] => Future[Result]): Action[AnyContent] =
+  def onlyForClients(action: Request[AnyContent] => ClientIdentifier[MtdItId] => Future[Result]): Action[AnyContent] =
     super.onlyForClients(Service.MtdIt, MtdItIdType.enrolmentId)(action)(MtdItId.apply)
 
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/NiClientInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/NiClientInvitationsController.scala
@@ -67,6 +67,6 @@ class NiClientInvitationsController @Inject()(invitationsService: InvitationsSer
   }
 
   def onlyForClients(action: Request[AnyContent] => ClientIdentifier[Nino] => Future[Result]): Action[AnyContent] =
-    super.onlyForClients(Service.PersonalIncomeRecord, NinoType.enrolmentId)(action)(Nino.apply)
+    super.onlyForClients(Service.PersonalIncomeRecord, NinoType)(action)
 
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/NiClientInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/NiClientInvitationsController.scala
@@ -22,7 +22,7 @@ import com.kenshoo.play.metrics.Metrics
 import play.api.mvc.{Action, AnyContent, Request, Result}
 import uk.gov.hmrc.agentclientauthorisation.{MicroserviceAuthConnector, _}
 import uk.gov.hmrc.agentclientauthorisation.audit.AuditService
-import uk.gov.hmrc.agentclientauthorisation.model.{ClientId, InvitationStatus, NinoType, Service}
+import uk.gov.hmrc.agentclientauthorisation.model.{ClientIdentifier, InvitationStatus, NinoType, Service}
 import uk.gov.hmrc.agentclientauthorisation.service.InvitationsService
 import uk.gov.hmrc.agentmtdidentifiers.model.InvitationId
 import uk.gov.hmrc.domain.Nino
@@ -40,33 +40,33 @@ class NiClientInvitationsController @Inject()(invitationsService: InvitationsSer
 
   def getDetailsForClient(nino: Nino): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authNino => getDetailsForClient(ClientId(nino), request)
+      implicit authNino => getDetailsForClient(ClientIdentifier(nino), request)
   }
 
   def acceptInvitation(nino: Nino, invitationId: InvitationId): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authNino => acceptInvitation(ClientId(nino), invitationId)
+      implicit authNino => acceptInvitation(ClientIdentifier(nino), invitationId)
   }
 
   def rejectInvitation(nino: Nino, invitationId: InvitationId): Action[AnyContent] = onlyForClients {
     implicit request =>
       implicit authNino =>
-        forThisClient(ClientId(nino)) {
-          actionInvitation(ClientId(nino), invitationId, invitationsService.rejectInvitation)
+        forThisClient(ClientIdentifier(nino)) {
+          actionInvitation(ClientIdentifier(nino), invitationId, invitationsService.rejectInvitation)
         }
   }
 
   def getInvitation(nino: Nino, invitationId: InvitationId): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authNino => getInvitation(ClientId(nino), invitationId)
+      implicit authNino => getInvitation(ClientIdentifier(nino), invitationId)
   }
 
   def getInvitations(nino: Nino, status: Option[InvitationStatus]): Action[AnyContent] = onlyForClients {
     implicit request =>
-      implicit authNino => getInvitations(ClientId(nino), status)
+      implicit authNino => getInvitations(ClientIdentifier(nino), status)
   }
 
-  def onlyForClients(action: Request[AnyContent] => ClientId[Nino] => Future[Result]): Action[AnyContent] =
+  def onlyForClients(action: Request[AnyContent] => ClientIdentifier[Nino] => Future[Result]): Action[AnyContent] =
     super.onlyForClients(Service.PersonalIncomeRecord, NinoType.enrolmentId)(action)(Nino.apply)
 
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsController.scala
@@ -19,11 +19,12 @@ package uk.gov.hmrc.agentclientauthorisation.controllers.sandbox
 import javax.inject.Singleton
 
 import org.joda.time.DateTime.now
+import org.joda.time.LocalDate
 import play.api.mvc.Action
-import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.agentclientauthorisation.controllers.{routes => prodroutes, _}
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 @Singleton
@@ -62,16 +63,15 @@ class SandboxAgencyInvitationsController extends BaseController with HalWriter w
   }
 
   private def invitation(arn: Arn) = Invitation(
-        BSONObjectID.generate,
-        InvitationId("ABBBBBBBBBBCC"),
-        arn,
-        Service.MtdIt,
-        "clientId",
-        Some("A11 1AA"),
-        "nino",
-        NinoType.id,
-        List(StatusChangeEvent(now(), Pending))
-      )
+    invitationId = InvitationId("ABBBBBBBBBBCC"),
+    arn = arn,
+    service = Service.MtdIt,
+    clientId = ClientIdentifier(Nino("AA123456A")),
+    suppliedClientId = ClientIdentifier(Nino("AA123456A")),
+    postcode = Some("A11 1AA"),
+    expiryDate = LocalDate.now().plusDays(10),
+    events = List(StatusChangeEvent(now(), Pending))
+  )
 
   override protected def agencyLink(invitation: Invitation) = None
 }

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/sandbox/SandboxAgencyInvitationsISpec.scala
@@ -106,7 +106,7 @@ class SandboxAgencyInvitationsISpec extends UnitSpec with MongoAppAndStubs with 
     (invitation \ "arn").as[String] shouldBe arn.value
     (invitation \ "service").as[String] shouldBe MtdItService
     (invitation \ "clientIdType").as[String] shouldBe "ni"
-    (invitation \ "clientId").as[String] shouldBe "clientId"
+    (invitation \ "clientId").as[String] shouldBe "AA123456A"
     (invitation \ "status").as[String] shouldBe "Pending"
     (invitation \ "created").as[DateTime].getMillis should beRecent
     (invitation \ "lastUpdated").as[DateTime].getMillis should beRecent

--- a/it/uk/gov/hmrc/agentclientauthorisation/scenarios/AgencyFilteringByClientIdIApiPlatformISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/scenarios/AgencyFilteringByClientIdIApiPlatformISpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentclientauthorisation.scenarios
 
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
-import uk.gov.hmrc.agentclientauthorisation.model.ClientId
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier.ClientId
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants.mtdItId1
 import uk.gov.hmrc.agentclientauthorisation.support._
 import uk.gov.hmrc.agentmtdidentifiers.model.MtdItId
@@ -59,7 +59,7 @@ class AgencyFilteringByClientIdIApiPlatformISpec extends FeatureSpec with Scenar
     }
   }
 
-  private def agencyFiltersById(agency: AgencyApi, clientId: ClientId[_]): Unit = {
+  private def agencyFiltersById(agency: AgencyApi, clientId: ClientId): Unit = {
     val invitation = agency.sentInvitations(filteredBy = Seq("clientId" -> clientId.value))
     invitation.numberOfInvitations shouldBe 1
     invitation.firstInvitation.status shouldBe "Pending"

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/ApiRequests.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/ApiRequests.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.agentclientauthorisation.support
 
-import uk.gov.hmrc.agentclientauthorisation.model.ClientId
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier.ClientId
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -95,14 +96,14 @@ trait ApiRequests {
    */
   def clientsUrl = s"$baseUrl/clients"
 
-  def clientUrl(clientId: ClientId[_]) = clientId match {
-    case ClientId(MtdItId(value)) => s"$baseUrl/clients/MTDITID/$value"
-    case ClientId(Nino(value)) => s"$baseUrl/clients/NI/$value"
+  def clientUrl(clientId: ClientId) = clientId match {
+    case ClientIdentifier(MtdItId(value)) => s"$baseUrl/clients/MTDITID/$value"
+    case ClientIdentifier(Nino(value)) => s"$baseUrl/clients/NI/$value"
   }
 
-  def clientReceivedInvitationsUrl(clientId: ClientId[_]) = s"${clientUrl(clientId)}/invitations/received"
+  def clientReceivedInvitationsUrl(clientId: ClientId) = s"${clientUrl(clientId)}/invitations/received"
 
-  def clientReceivedInvitationUrl(clientId: ClientId[_], invitationId:String): String = s"${clientUrl(clientId)}/invitations/received/$invitationId"
+  def clientReceivedInvitationUrl(clientId: ClientId, invitationId:String): String = s"${clientUrl(clientId)}/invitations/received/$invitationId"
 
   def clientsResource()(implicit port: Int) = {
     new Resource(clientsUrl, port).get
@@ -111,7 +112,7 @@ trait ApiRequests {
   def clientResource(mtdItId: MtdItId)(implicit port: Int) = {
     new Resource(clientUrl(mtdItId), port).get
   }
-  def clientGetReceivedInvitations(clientId: ClientId[_], filteredBy: Seq[(String, String)] = Nil)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
+  def clientGetReceivedInvitations(clientId: ClientId, filteredBy: Seq[(String, String)] = Nil)(implicit port: Int, hc: HeaderCarrier): HttpResponse = {
     val params = withFilterParams(filteredBy)
     new Resource(clientReceivedInvitationsUrl(clientId) + params, port).get()(hc)
   }

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/ClientApi.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/ClientApi.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.agentclientauthorisation.support
 
-import uk.gov.hmrc.agentclientauthorisation.model.ClientId
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier.ClientId
 import uk.gov.hmrc.agentclientauthorisation.support.EmbeddedSection.EmbeddedInvitation
 import uk.gov.hmrc.agentclientauthorisation.support.HalTestHelpers.HalResourceHelper
 import uk.gov.hmrc.agentmtdidentifiers.model.MtdItId
@@ -24,7 +24,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.logging.SessionId
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
-class ClientApi(val apiRequests: ApiRequests, val suppliedClientId: Nino, val clientId: ClientId[_] = MtdItId("mtdItId"), implicit val port: Int) {
+class ClientApi(val apiRequests: ApiRequests, val suppliedClientId: Nino, val clientId: ClientId = MtdItId("mtdItId"), implicit val port: Int) {
 
   implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(suppliedClientId.value)))
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/ScenarioHelpers.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/ScenarioHelpers.scala
@@ -18,10 +18,11 @@ package uk.gov.hmrc.agentclientauthorisation.support
 
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
-import uk.gov.hmrc.agentclientauthorisation.model.{ClientId, Service}
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier.ClientId
+import uk.gov.hmrc.agentclientauthorisation.model.Service
 import uk.gov.hmrc.agentclientauthorisation.support.EmbeddedSection.EmbeddedInvitation
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants.mtdItId1
-import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId}
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.domain.TaxIdentifier
 
 trait ScenarioHelpers extends ApiRequests with Matchers with Eventually {
@@ -48,9 +49,9 @@ trait ScenarioHelpers extends ApiRequests with Matchers with Eventually {
     checkInvite(response.firstInvitation)(firstClient._1.clientId, firstClient._2)
     checkInvite(response.secondInvitation)(secondClient._1.clientId, secondClient._2)
 
-    def checkInvite(invitation: EmbeddedInvitation)(expectedClientId:ClientId[_], expectedService: String): Unit = {
+    def checkInvite(invitation: EmbeddedInvitation)(expectedClientId:ClientId, expectedService: String): Unit = {
       invitation.arn shouldBe arn
-      invitation.clientIdType shouldBe "ni"
+      invitation.clientIdType shouldBe expectedClientId.typeId
       invitation.clientId shouldBe expectedClientId.value
       invitation.service shouldBe expectedService
       invitation.status shouldBe "Pending"

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/StubUtils.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/StubUtils.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.agentclientauthorisation.support
 
-import uk.gov.hmrc.agentclientauthorisation.model.ClientId
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants.nino1
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId}
 import uk.gov.hmrc.domain._

--- a/test/uk/gov/hmrc/agentclientauthorisation/audit/AuditSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/audit/AuditSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
 import play.api.test.FakeRequest
-import uk.gov.hmrc.agentclientauthorisation.model.{ClientId, Service}
+import uk.gov.hmrc.agentclientauthorisation.model.{ClientIdentifier, Service}
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants.mtdItId1
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.http.HeaderCarrier
@@ -52,7 +52,7 @@ class AuditSpec extends UnitSpec with MockitoSugar with Eventually {
       await(service.sendAgentClientRelationshipCreated(
         invitationId,
         arn,
-        ClientId(mtdItId1), Service.MtdIt)(
+        ClientIdentifier(mtdItId1), Service.MtdIt)(
         hc,
         FakeRequest("GET", "/path")))
 

--- a/test/uk/gov/hmrc/agentclientauthorisation/connectors/AuthConnectorSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/connectors/AuthConnectorSpec.scala
@@ -26,7 +26,8 @@ import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientauthorisation._
-import uk.gov.hmrc.agentclientauthorisation.model.{ClientId, MtdItIdType, NinoType, Service}
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier.ClientId
+import uk.gov.hmrc.agentclientauthorisation.model.{MtdItIdType, NinoType, Service}
 import uk.gov.hmrc.agentclientauthorisation.model.Service.PersonalIncomeRecord
 import uk.gov.hmrc.agentclientauthorisation.support.TestData
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId}
@@ -44,7 +45,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
   val mockAuthConnector: AuthConnector = new AuthConnector(mockMetrics, mockPlayAuthConnector)
 
   private type AgentAuthAction = Request[AnyContent] => Arn => Future[Result]
-  private type ClientAuthAction = Request[AnyContent] => ClientId[_] => Future[Result]
+  private type ClientAuthAction = Request[AnyContent] => ClientId => Future[Result]
 
   val agentAction: AgentAuthAction = { implicit request => implicit arn => Future successful Ok }
   val clientAction: ClientAuthAction = { implicit request => implicit clientId => Future successful Ok }

--- a/test/uk/gov/hmrc/agentclientauthorisation/connectors/AuthConnectorSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/connectors/AuthConnectorSpec.scala
@@ -104,7 +104,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
     "successfully grant access to a Client with HMRC-MTD-IT enrolment and Service is MTD-IT" in {
       clientAuthStub(clientMtdItEnrolments)
 
-      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType.enrolmentId)(clientAction)(MtdItId.apply).apply(FakeRequest()))
+      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType)(clientAction).apply(FakeRequest()))
 
       status(response) shouldBe OK
     }
@@ -112,7 +112,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
     "successfully grant access to a Client with HMRC-NI enrolment and Service is PersonalIncomeRecord" in {
       clientAuthStub(clientNiEnrolments)
 
-      val response = await(mockAuthConnector.onlyForClients(Service.PersonalIncomeRecord, NinoType.enrolmentId)(clientAction)(Nino.apply).apply(FakeRequest()))
+      val response = await(mockAuthConnector.onlyForClients(Service.PersonalIncomeRecord, NinoType)(clientAction).apply(FakeRequest()))
 
       status(response) shouldBe OK
     }
@@ -120,7 +120,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
     "return FORBIDDEN when the user has no HMRC-NI enrolment and Service is PersonalIncomeRecord" in {
       clientAuthStub(clientNoEnrolments)
 
-      val response: Result = await(mockAuthConnector.onlyForClients(Service.PersonalIncomeRecord, MtdItIdType.enrolmentId)(clientAction)(Nino.apply).apply(FakeRequest()))
+      val response: Result = await(mockAuthConnector.onlyForClients(Service.PersonalIncomeRecord, MtdItIdType)(clientAction).apply(FakeRequest()))
 
       status(response) shouldBe FORBIDDEN
     }
@@ -128,7 +128,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
     "return FORBIDDEN when the user has no HMRC-MTD-IT enrolment and Service is MTD-IT" in {
       clientAuthStub(clientNoEnrolments)
 
-      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType.enrolmentId)(clientAction)(MtdItId.apply).apply(FakeRequest()))
+      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType)(clientAction).apply(FakeRequest()))
 
       status(response) shouldBe FORBIDDEN
     }
@@ -136,7 +136,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
     "return FORBIDDEN when the user has HMRC-MTD-IT enrolment and Service is PersonalIncomeRecord" in {
       clientAuthStub(clientMtdItEnrolments)
 
-      val response: Result = await(mockAuthConnector.onlyForClients(PersonalIncomeRecord, MtdItIdType.enrolmentId)(clientAction)(Nino.apply).apply(FakeRequest()))
+      val response: Result = await(mockAuthConnector.onlyForClients(PersonalIncomeRecord, MtdItIdType)(clientAction).apply(FakeRequest()))
 
       status(response) shouldBe FORBIDDEN
     }
@@ -144,7 +144,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
     "return FORBIDDEN when the user has HMRC-NI enrolment and Service is MTD-IT" in {
       clientAuthStub(clientNiEnrolments)
 
-      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType.enrolmentId)(clientAction)(MtdItId.apply).apply(FakeRequest()))
+      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType)(clientAction).apply(FakeRequest()))
 
       status(response) shouldBe FORBIDDEN
     }
@@ -152,7 +152,7 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEa
     "return UNAUTHORISED when auth throws an error" in {
       clientAuthStub(failedStubForClient)
 
-      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType.enrolmentId)(clientAction)(MtdItId.apply).apply(FakeRequest()))
+      val response: Result = await(mockAuthConnector.onlyForClients(Service.MtdIt, MtdItIdType)(clientAction).apply(FakeRequest()))
 
       status(response) shouldBe UNAUTHORIZED
     }

--- a/test/uk/gov/hmrc/agentclientauthorisation/controllers/MtdItClientInvitationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/controllers/MtdItClientInvitationsControllerSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.agentclientauthorisation.controllers.ErrorResults._
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentclientauthorisation.service.StatusUpdateFailure
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants.{mtdItId1, nino1}
-import uk.gov.hmrc.agentclientauthorisation.support.{AkkaMaterializerSpec, ClientEndpointBehaviours, ResettingMockitoSugar, TestData}
+import uk.gov.hmrc.agentclientauthorisation.support._
 import uk.gov.hmrc.agentmtdidentifiers.model.{InvitationId, MtdItId}
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.auth.core.{Enrolments, PlayAuthConnector}
@@ -204,9 +204,9 @@ class MtdItClientInvitationsControllerSpec extends AkkaMaterializerSpec with Res
     "not include the invitation ID in invitations to encourage HATEOAS API usage" in {
       clientAuthStub(clientMtdItEnrolments)
       whenClientReceivedInvitation.thenReturn(Future successful List(
-        Invitation(
-          BSONObjectID("abcdefabcdefabcdefabcdef"), invitationId, arn, Service.MtdIt, mtdItId1.value, Some("postcode"), nino1.value, "ni",
-          List(StatusChangeEvent(new DateTime(2016, 11, 1, 11, 30), Accepted)))))
+        TestConstants.defaultInvitation.copy(invitationId = invitationId, arn = arn, clientId = mtdItId1, suppliedClientId = nino1,
+          events = List(StatusChangeEvent(new DateTime(2016, 11, 1, 11, 30), Accepted)))
+        ))
 
       val result: Result = await(controller.getInvitations(mtdItId1, None)(FakeRequest()))
       status(result) shouldBe 200

--- a/test/uk/gov/hmrc/agentclientauthorisation/model/InvitationSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/model/InvitationSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.agentclientauthorisation.model
 import org.joda.time.DateTime.parse
 import play.api.libs.json.Json.toJson
 import reactivemongo.bson.BSONObjectID
+import uk.gov.hmrc.agentclientauthorisation.support.TestConstants
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -27,15 +28,12 @@ class InvitationSpec extends UnitSpec {
     "be in ISO8601 format" in {
       val created = "2010-01-01T01:00:23.456Z"
       val lastUpdated = "2010-01-02T04:00:23.456Z"
-      val invitation = Invitation(
-        id = BSONObjectID.generate,
+
+      val invitation = TestConstants.defaultInvitation.copy(
         invitationId = InvitationId("ABBBBBBBBBBCC"),
         arn = Arn("myAgency"),
         service = Service.MtdIt,
-        clientId = "clientId",
         postcode = Some("A11 1AA"),
-        suppliedClientId = "nino1",
-        suppliedClientIdType = "ni",
         events = List(StatusChangeEvent(parse(created), Pending), StatusChangeEvent(parse(lastUpdated), Accepted))
       )
 

--- a/test/uk/gov/hmrc/agentclientauthorisation/service/InvitationsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/service/InvitationsServiceSpec.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.agentclientauthorisation.service
 
-import org.joda.time.DateTime
+import com.sun.jndi.ldap.ClientId
+import org.joda.time.{DateTime, LocalDate}
 import org.joda.time.DateTime.now
 import org.mockito.ArgumentMatchers.{any, eq => eqs, _}
 import play.api.mvc.Request
@@ -26,7 +27,6 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mock.MockitoSugar
 import play.api.test.FakeRequest
 import play.api.libs.json.JsObject
-import play.api.libs.json.Json.JsValueWrapper
 import reactivemongo.bson.BSONObjectID
 import reactivemongo.bson.BSONObjectID.generate
 import reactivemongo.core.errors.ReactiveMongoException
@@ -85,10 +85,10 @@ class InvitationsServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAf
             InvitationId.create(arn, mtdItId1.value, Service.PersonalIncomeRecord.id, DateTime.parse("2001-01-01"))('B'),
             Arn(arn),
             Service.PersonalIncomeRecord,
-            nino1.value,
+            ClientIdentifier(nino1),
+            ClientIdentifier(nino1),
             Some("A11 1AA"),
-            nino1.value,
-            "ni",
+            now().toLocalDate.plusDays(10),
             List(StatusChangeEvent(now(), Pending)))
 
         whenAfiRelationshipIsCreated(invitation) thenReturn (Future successful {})
@@ -348,10 +348,10 @@ class InvitationsServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAf
     InvitationId.create(arn, mtdItId1.value, "mtd-sa", DateTime.parse("2001-01-01"))('A'),
     Arn(arn),
     Service.MtdIt,
-    mtdItId1.value,
+    mtdItId1,
+    ClientIdentifier(nino1),
     Some("A11 1AA"),
-    nino1.value,
-    "ni",
+    LocalDate.now().plusDays(10),
     List(StatusChangeEvent(now(), Pending), StatusChangeEvent(now(), status))
   )
 
@@ -361,10 +361,10 @@ class InvitationsServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAf
     InvitationId.create(arn, mtdItId1.value, "mtd-sa", DateTime.parse("2001-01-01"))('A'),
     Arn(arn),
     Service.MtdIt,
-    mtdItId1.value,
+    ClientIdentifier(mtdItId1),
+    ClientIdentifier(nino1),
     Some("A11 1AA"),
-    nino1.value,
-    "ni",
+    LocalDate.now().plusDays(10),
     List(StatusChangeEvent(creationDate(), Pending))
   )
 

--- a/test/uk/gov/hmrc/agentclientauthorisation/support/ClientEndpointBehaviours.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/support/ClientEndpointBehaviours.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.agentclientauthorisation.audit.AuditService
 import uk.gov.hmrc.agentclientauthorisation.connectors.AuthConnector
 import uk.gov.hmrc.agentclientauthorisation.controllers.MtdItClientInvitationsController
 import uk.gov.hmrc.agentclientauthorisation.model._
+import uk.gov.hmrc.agentclientauthorisation.model.ClientIdentifier._
 import uk.gov.hmrc.agentclientauthorisation.service.{InvitationsService, StatusUpdateFailure}
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants.{mtdItId1, nino1}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId}
@@ -65,8 +66,10 @@ trait ClientEndpointBehaviours extends TransitionInvitation with Eventually {
 
   def noInvitation: Future[None.type] = Future successful None
 
-  def anInvitation(nino: Nino) = Invitation(BSONObjectID(invitationDbId), invitationId, arn, Service.MtdIt, mtdItId1.value, Some("A11 1AA"), nino.value, "ni",
-    List(StatusChangeEvent(now(), Pending)))
+  def anInvitation(nino: Nino) = TestConstants.defaultInvitation.copy(
+    id = BSONObjectID(invitationDbId), invitationId = invitationId, arn = arn,
+    clientId = ClientIdentifier(mtdItId1), suppliedClientId = ClientIdentifier(nino)
+  )
 
   def aFutureOptionInvitation(): Future[Option[Invitation]] =
     Future successful Some(anInvitation(nino1))

--- a/test/uk/gov/hmrc/agentclientauthorisation/support/TestData.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/support/TestData.scala
@@ -40,9 +40,9 @@ trait TestData {
   val otherRegimePendingInvitationId: InvitationId = InvitationId.create(arn.value, mtdItId1.value, "mtd-other", DateTime.parse("2001-01-03"))('A')
 
   val allInvitations = List(
-    Invitation(mtdSaPendingInvitationDbId, mtdSaPendingInvitationId, arn, Service.MtdIt, mtdItId1.value, Some("postcode"), nino1.value, "ni", events = List(StatusChangeEvent(now(), Pending))),
-    Invitation(mtdSaAcceptedInvitationDbId, mtdSaAcceptedInvitationId, arn, Service.MtdIt, mtdItId1.value, Some("postcode"), nino1.value, "ni", events = List(StatusChangeEvent(now(), Accepted))),
-    Invitation(otherRegimePendingInvitationDbId, otherRegimePendingInvitationId, arn, Service.PersonalIncomeRecord, mtdItId1.value, Some("postcode"), nino1.value, "ni", events = List(StatusChangeEvent(now(), Pending)))
+    Invitation(mtdSaPendingInvitationDbId, mtdSaPendingInvitationId, arn, Service.MtdIt, mtdItId1, ClientIdentifier(nino1.value, "ni"), Some("postcode"), now().toLocalDate.plusDays(100), events = List(StatusChangeEvent(now(), Pending))),
+    Invitation(mtdSaAcceptedInvitationDbId, mtdSaAcceptedInvitationId, arn, Service.MtdIt, mtdItId1, ClientIdentifier(nino1.value, "ni"), Some("postcode"), now().toLocalDate.plusDays(100), events = List(StatusChangeEvent(now(), Accepted))),
+    Invitation(otherRegimePendingInvitationDbId, otherRegimePendingInvitationId, arn, Service.PersonalIncomeRecord, mtdItId1, ClientIdentifier(nino1.value, "ni"), Some("postcode"), now().toLocalDate.plusDays(100), events = List(StatusChangeEvent(now(), Pending)))
   )
 
   val agentEnrolment = Set(

--- a/testcommon/uk/gov/hmrc/agentclientauthorisation/support/TestConstants.scala
+++ b/testcommon/uk/gov/hmrc/agentclientauthorisation/support/TestConstants.scala
@@ -16,7 +16,9 @@
 
 package uk.gov.hmrc.agentclientauthorisation.support
 
-import uk.gov.hmrc.agentmtdidentifiers.model.MtdItId
+import org.joda.time.{DateTime, LocalDate}
+import uk.gov.hmrc.agentclientauthorisation.model._
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId, MtdItId}
 import uk.gov.hmrc.domain.{Generator, Nino}
 
 object TestConstants {
@@ -30,4 +32,14 @@ object TestConstants {
   val agentCode = "12345"
 
   val MtdItService = "HMRC-MTD-IT"
+
+  val defaultInvitation = Invitation(
+    invitationId = InvitationId("ABBBBBBBBBBCC"),
+    arn = Arn("98765"),
+    service = Service.MtdIt,
+    clientId = ClientIdentifier(Nino("AA123456A")),
+    suppliedClientId = ClientIdentifier(Nino("AA123456A")),
+    postcode = Some("A11 1AA"),
+    expiryDate = LocalDate.now().plusDays(10),
+    events = List(StatusChangeEvent(DateTime.now(), Pending)))
 }


### PR DESCRIPTION
These changes also include the use of ClientId on the Invitation  model replacing the raw String types, this was introduced now rather than in 1831 (when ClientId was introduced) as it required implementing a custom Json.Format for persistence which was also required to ensure we default to a sensible value for any old records that don't have a expiryDate. 