### PR TITLE
[APB-3376][AO] define failoverStrategy for mongodb connector, upgrade simple-reactivemongo to 7.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val compileDeps = Seq(
   "uk.gov.hmrc" %% "domain" % "5.3.0",
   "com.github.blemale" %% "scaffeine" % "2.5.0",
   "uk.gov.hmrc" %% "agent-kenshoo-monitoring" % "3.4.0",
-  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.9.0-play-25",
+  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.12.0-play-25",
   "uk.gov.hmrc" %% "play-config" % "7.2.0",
   "uk.gov.hmrc" %% "play-hal" % "1.8.0-play-25"
 )
@@ -33,9 +33,9 @@ lazy val compileDeps = Seq(
 def testDeps(scope: String) = Seq(
   "uk.gov.hmrc" %% "hmrctest" % "3.4.0-play-25" % scope,
   "org.scalatest" %% "scalatest" % "3.0.5" % scope,
-  "org.mockito" % "mockito-core" % "2.23.4" % scope,
+  "org.mockito" % "mockito-core" % "2.24.0" % scope,
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % scope,
-  "uk.gov.hmrc" %% "reactivemongo-test" % "4.6.0-play-25" % scope,
+  "uk.gov.hmrc" %% "reactivemongo-test" % "4.7.0-play-25" % scope,
   "com.github.tomakehurst" % "wiremock" % "2.21.0" % scope,
   "org.pegdown" % "pegdown" % "1.6.0" % scope,
   "com.typesafe.play" %% "play-test" % PlayVersion.current % scope

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -124,6 +124,14 @@ auditing {
 
 mongodb {
   uri = "mongodb://localhost:27017/agent-client-authorisation"
+  failoverStrategy {
+    initialDelayMsecs = 100
+    retries = 10
+    delay {
+      factor = 1.25
+      function = fibonacci
+    }
+  }
 }
 
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsMongoRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsMongoRepositoryISpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.mockito.MockitoSugar
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.FailoverStrategy
 import reactivemongo.bson.BSONObjectID
 import reactivemongo.bson.BSONObjectID.parse
 import uk.gov.hmrc.agentclientauthorisation.model
@@ -32,7 +33,7 @@ import uk.gov.hmrc.agentclientauthorisation.support.TestConstants._
 import uk.gov.hmrc.agentclientauthorisation.support.{MongoApp, ResetMongoBeforeTest}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, InvitationId, MtdItId, Vrn}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -41,6 +42,9 @@ import scala.concurrent.Future
 class InvitationsMongoRepositoryISpec
     extends UnitSpec with MongoSpecSupport with ResetMongoBeforeTest with Eventually with Inside with MockitoSugar
     with MongoApp {
+
+  override implicit lazy val mongoConnectorForTest: MongoConnector =
+    MongoConnector(mongoUri, Some(MongoApp.failoverStrategyForTest))
 
   private val now = DateTime.now()
   val date = LocalDate.now()

--- a/it/uk/gov/hmrc/agentclientauthorisation/repository/MongoAgentReferenceRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/repository/MongoAgentReferenceRepositoryISpec.scala
@@ -21,10 +21,11 @@ import org.scalatest.mockito.MockitoSugar
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.FailoverStrategy
 import reactivemongo.core.errors.DatabaseException
 import uk.gov.hmrc.agentclientauthorisation.support.{MongoApp, ResetMongoBeforeTest}
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -32,7 +33,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class MongoAgentReferenceRepositoryISpec
     extends UnitSpec with MongoSpecSupport with ResetMongoBeforeTest with MockitoSugar with MongoApp {
 
-  private val now = DateTime.now()
+  override implicit lazy val mongoConnectorForTest: MongoConnector =
+    MongoConnector(mongoUri, Some(MongoApp.failoverStrategyForTest))
 
   lazy val app: Application = appBuilder
     .build()

--- a/it/uk/gov/hmrc/agentclientauthorisation/repository/ScheduleRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/repository/ScheduleRepositoryISpec.scala
@@ -6,14 +6,18 @@ import org.joda.time.DateTime
 import org.scalatest.mockito.MockitoSugar
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import reactivemongo.api.FailoverStrategy
 import uk.gov.hmrc.agentclientauthorisation.support.{MongoApp, ResetMongoBeforeTest}
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ScheduleRepositoryISpec
     extends UnitSpec with MongoSpecSupport with ResetMongoBeforeTest with MockitoSugar with MongoApp {
+
+  override implicit lazy val mongoConnectorForTest: MongoConnector =
+    MongoConnector(mongoUri, Some(MongoApp.failoverStrategyForTest))
 
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/AppAndStubs.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/AppAndStubs.scala
@@ -21,10 +21,10 @@ import org.scalatestplus.play.OneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeApplication
-import reactivemongo.api.DB
+import reactivemongo.api.{DB, FailoverStrategy}
 import uk.gov.hmrc.agentclientauthorisation.repository.InvitationsRepository
 import uk.gov.hmrc.domain.Generator
-import uk.gov.hmrc.mongo.{MongoSpecSupport, Awaiting => MongoAwaiting}
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport, Awaiting => MongoAwaiting}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.it.Port
 
@@ -86,6 +86,9 @@ trait AppAndStubs
 
 trait MongoAppAndStubs extends AppAndStubs with MongoSpecSupport with ResetMongoBeforeTest with Matchers {
   me: Suite with TestSuite =>
+
+  override implicit lazy val mongoConnectorForTest: MongoConnector =
+    MongoConnector(mongoUri, Some(MongoApp.failoverStrategyForTest))
 
   lazy val db: InvitationsRepository = app.injector.instanceOf[InvitationsRepository]
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/MongoApp.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/MongoApp.scala
@@ -1,10 +1,21 @@
 package uk.gov.hmrc.agentclientauthorisation.support
 
 import org.scalatest.Suite
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import reactivemongo.api.FailoverStrategy
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
 
 trait MongoApp extends MongoSpecSupport {
   me: Suite =>
 
   protected def mongoConfiguration = Map("mongodb.uri" -> mongoUri)
+
+  override implicit lazy val mongoConnectorForTest: MongoConnector =
+    MongoConnector(mongoUri, Some(MongoApp.failoverStrategyForTest))
+}
+
+object MongoApp {
+
+  import scala.concurrent.duration._
+  val failoverStrategyForTest = FailoverStrategy(50.millis, 5, _ * 1.618)
+
 }


### PR DESCRIPTION
This PR aims to fix the random "No primary node is available" problems occurring on the local environment when running tests or service. We define now the failover strategy, previously missing.