### PR TITLE
[APB-4475][JR]

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
@@ -110,6 +110,7 @@ case class Invitation(
   suppliedClientId: ClientId,
   expiryDate: LocalDate,
   detailsForEmail: Option[DetailsForEmail],
+  isRelationshipEnded: Boolean = false,
   clientActionUrl: Option[String],
   events: List[StatusChangeEvent]) {
 
@@ -169,6 +170,7 @@ object Invitation {
           "status"               -> invitation.status,
           "invitationId"         -> invitation.invitationId.value,
           "detailsForEmail"      -> invitation.detailsForEmail,
+          "isRelationshipEnded"  -> invitation.isRelationshipEnded,
           "clientActionUrl"      -> invitation.clientActionUrl
         )
     }

--- a/app/uk/gov/hmrc/agentclientauthorisation/repository/InvitationRecordFormat.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/repository/InvitationRecordFormat.scala
@@ -41,6 +41,7 @@ object InvitationRecordFormat {
     suppliedClientIdType: String,
     expiryDateOp: Option[LocalDate],
     detailsForEmail: Option[DetailsForEmail],
+    isRelationshipEnded: Boolean = false,
     clientActionUrl: Option[String],
     events: List[StatusChangeEvent]): Invitation = {
 
@@ -60,6 +61,7 @@ object InvitationRecordFormat {
       ClientIdentifier(suppliedClientId, suppliedClientIdType),
       expiryDate,
       detailsForEmail,
+      isRelationshipEnded,
       None,
       events
     )
@@ -78,6 +80,7 @@ object InvitationRecordFormat {
     (JsPath \ "suppliedClientIdType").read[String] and
     (JsPath \ "expiryDate").readNullable[LocalDate] and
     (JsPath \ "detailsForEmail").readNullable[DetailsForEmail] and
+    (JsPath \ "isRelationshipEnded").readWithDefault[Boolean](false) and
     (JsPath \ "clientActionUrl").readNullable[String] and
     (JsPath \ "events").read[List[StatusChangeEvent]])(read _)
 
@@ -100,6 +103,7 @@ object InvitationRecordFormat {
         "suppliedClientIdType" -> invitation.suppliedClientId.typeId,
         "events"               -> invitation.events,
         "detailsForEmail"      -> invitation.detailsForEmail,
+        "isRelationshipEnded"  -> invitation.isRelationshipEnded,
         "clientActionUrl"      -> invitation.clientActionUrl,
         "expiryDate"           -> invitation.expiryDate,
         createdKey             -> invitation.firstEvent().time.getMillis,

--- a/app/uk/gov/hmrc/agentclientauthorisation/service/InvitationsService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/service/InvitationsService.scala
@@ -261,6 +261,13 @@ class InvitationsService @Inject()(
             Right(invitation)
           }
         }
+      case Accepted if status == Cancelled =>
+        monitor(s"Repository-Change-Invitation-${invitation.service.id}-flagRelationshipEnded") {
+          invitationsRepository.setRelationshipEnded(invitation) map { invitation =>
+            Logger info s"""Invitation with id: "${invitation.id.stringify}" has been flagged as isRelationshipEnded = true"""
+            Right(invitation)
+          }
+        }
       case _ => Future successful cannotTransitionBecauseNotPending(invitation, status)
     }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsMongoRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/repository/InvitationsMongoRepositoryISpec.scala
@@ -57,6 +57,7 @@ class InvitationsMongoRepositoryISpec
     nino1,
     date,
     None,
+    false,
     None,
     List.empty)
   val invitationIRV = Invitation(
@@ -69,6 +70,7 @@ class InvitationsMongoRepositoryISpec
     nino1,
     date,
     None,
+    false,
     None,
     List.empty)
   val invitationVAT = Invitation(
@@ -81,6 +83,7 @@ class InvitationsMongoRepositoryISpec
     vrn,
     date,
     None,
+    false,
     None,
     List.empty)
 
@@ -110,7 +113,7 @@ class InvitationsMongoRepositoryISpec
 
   "create" should {
     "create a new StatusChangedEvent of Pending" in inside(addInvitation(now, invitationITSA)) {
-      case Invitation(_, _, arnValue, _, service, clientId, _, _, _, _, events) =>
+      case Invitation(_, _, arnValue, _, service, clientId, _, _, _, _, _, events) =>
         arnValue shouldBe Arn(arn)
         clientId shouldBe ClientIdentifier(mtdItId1)
         service shouldBe Service.MtdIt
@@ -128,6 +131,7 @@ class InvitationsMongoRepositoryISpec
       val foundInvitation: model.Invitation = await(repository.findById(reconstructedId)).head
 
       id shouldBe foundInvitation.id
+      foundInvitation.isRelationshipEnded shouldBe false
     }
   }
 
@@ -138,8 +142,23 @@ class InvitationsMongoRepositoryISpec
       val updated = update(created, Accepted, now)
 
       inside(updated) {
-        case Invitation(created.id, _, _, _, _, _, _, _,_, _, events) =>
+        case Invitation(created.id, _, _, _, _, _, _, _, _, _, _, events) =>
           events shouldBe List(StatusChangeEvent(now, Pending), StatusChangeEvent(now, Accepted))
+      }
+    }
+  }
+
+  "setRelationshipEnded" should {
+    "set isRelationshipEnded flag to be true" in {
+
+      val created = addInvitation(now, invitationITSA)
+      val updated = update(created, Accepted, now)
+      val ended   = setRelationshipEnded(created)
+
+
+      inside(ended) {
+        case Invitation(created.id, _, _, _, _, _, _, _, _, isRelationshipEnded, _, _) =>
+          isRelationshipEnded shouldBe true
       }
     }
   }
@@ -166,6 +185,7 @@ class InvitationsMongoRepositoryISpec
             _,
             _,
             _,
+            _,
             List(StatusChangeEvent(date1, Pending), StatusChangeEvent(date2, Accepted))) =>
           date1 shouldBe now
           date2 shouldBe now
@@ -173,7 +193,7 @@ class InvitationsMongoRepositoryISpec
       }
 
       inside(list(1)) {
-        case Invitation(_, _, Arn(`arn`), _, Service.MtdIt, _, _, _, _, _, List(StatusChangeEvent(date1, Pending))) =>
+        case Invitation(_, _, Arn(`arn`), _, Service.MtdIt, _, _, _, _, _, _, List(StatusChangeEvent(date1, Pending))) =>
           date1 shouldBe now
       }
     }
@@ -193,6 +213,7 @@ class InvitationsMongoRepositoryISpec
             _,
             Service.MtdIt,
             ClientIdentifier(`mtdItId1`),
+            _,
             _,
             _,
             _,
@@ -334,6 +355,7 @@ class InvitationsMongoRepositoryISpec
             _,
             _,
             _,
+            _,
             List(StatusChangeEvent(dateValue, Pending))) =>
           dateValue shouldBe now
       }
@@ -357,12 +379,12 @@ class InvitationsMongoRepositoryISpec
       requests.size shouldBe 2
 
       inside(requests.head) {
-        case Invitation(_, _, `firstAgent`, _, `service`, _, _, _, _, _, List(StatusChangeEvent(dateValue, Pending))) =>
+        case Invitation(_, _, `firstAgent`, _, `service`, _, _, _, _, _, _, List(StatusChangeEvent(dateValue, Pending))) =>
           dateValue shouldBe now
       }
 
       inside(requests(1)) {
-        case Invitation(_, _, `secondAgent`, _, `service`, _, _, _, _, _, List(StatusChangeEvent(dateValue, Pending))) =>
+        case Invitation(_, _, `secondAgent`, _, `service`, _, _, _, _, _, _, List(StatusChangeEvent(dateValue, Pending))) =>
           dateValue shouldBe now
       }
     }
@@ -557,7 +579,7 @@ class InvitationsMongoRepositoryISpec
 
   private def addInvitations(startDate: DateTime, invitations: Invitation*) =
     await(Future sequence invitations.map {
-      case Invitation(_, _, arnValue, clientType, service, clientId, suppliedClientId, _, _, _, _) =>
+      case Invitation(_, _, arnValue, clientType, service, clientId, suppliedClientId, _, _, _, _, _) =>
         repository.create(
           arnValue,
           clientType,
@@ -594,6 +616,9 @@ class InvitationsMongoRepositoryISpec
 
   private def update(invitation: Invitation, status: InvitationStatus, updateDate: DateTime) =
     await(repository.update(invitation, status, updateDate))
+
+  private def setRelationshipEnded(invitation: Invitation): Invitation =
+    await(repository.setRelationshipEnded(invitation))
 
   private def removeEmailDetails(invitation: Invitation) = await(repository.removeEmailDetails(invitation))
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/TestDataSupport.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/TestDataSupport.scala
@@ -101,6 +101,9 @@ trait TestDataSupport {
                         updateDate: DateTime)(implicit ec: ExecutionContext): Future[Invitation] =
       Future failed new Exception ("Unable to Update Invitation")
 
+    override def setRelationshipEnded(invitation: Invitation)(implicit ec: ExecutionContext): Future[Invitation] =
+      Future failed new Exception ("Unable to set isRelationshipEnded = true")
+
     override def findByInvitationId(invitationId: InvitationId)(
       implicit ec: ExecutionContext): Future[Option[Invitation]] =
       Future failed new Exception ("Unable to Find Invitation by ID")

--- a/test/uk/gov/hmrc/agentclientauthorisation/support/TestData.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/support/TestData.scala
@@ -54,6 +54,7 @@ trait TestData {
       ClientIdentifier(nino1.value, "ni"),
       now().toLocalDate.plusDays(100),
       None,
+      false,
       None,
       events = List(StatusChangeEvent(now(), Pending))
     ),
@@ -67,6 +68,7 @@ trait TestData {
       ClientIdentifier(nino1.value, "ni"),
       now().toLocalDate.plusDays(100),
       None,
+      false,
       None,
       events = List(StatusChangeEvent(now(), Accepted))
     ),
@@ -80,6 +82,7 @@ trait TestData {
       ClientIdentifier(nino1.value, "ni"),
       now().toLocalDate.plusDays(100),
       None,
+      false,
       None,
       events = List(StatusChangeEvent(now(), Pending))
     )


### PR DESCRIPTION
Add isRelationshipEnded flag to mongo invitation record. This is to enable us to decide whether or not to display the 'Cancel Authorisation' button on the track page - an ideal solution would've been for us to introduce a new InvitationStatus, however that would have affected all of our third party stakeholders. Also amended InvitationsService.changeInvitationStatus to facilitate the request - this may not make perfect sense as the InvitationStatus doesn't actually get updated, it remains as Accepted, instead the isRelationshipEnded flag gets set to true.