### PR TITLE
APB-5327 new audit event for when a Partialauth invitation expires

### DIFF
--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/TerminateInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/TerminateInvitationsISpec.scala
@@ -53,7 +53,7 @@ class TerminateInvitationsISpec extends BaseISpec {
     new AgentLinkService(agentReferenceRepository, desConnector, metrics)
 
   def testInvitationsService(invitationsRepository: InvitationsRepository, agentReferenceRepository: AgentReferenceRepository) =
-    new InvitationsService(invitationsRepository, relationshipConnector, analyticsService, desConnector, emailService, appConfig, metrics)
+    new InvitationsService(invitationsRepository, relationshipConnector, analyticsService, desConnector, emailService, auditService, appConfig, metrics)
 
   def testFailedController(invitationsRepository: InvitationsRepository, agentReferenceRepository: AgentReferenceRepository) =
     new AgencyInvitationsController(

--- a/it/uk/gov/hmrc/agentclientauthorisation/service/InvitationsStatusUpdateSchedulerISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/service/InvitationsStatusUpdateSchedulerISpec.scala
@@ -13,6 +13,7 @@ import uk.gov.hmrc.agentclientauthorisation.support.MongoAppAndStubs
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId}
 import uk.gov.hmrc.agentclientauthorisation.support.UnitSpec
 import play.api.test.Helpers._
+import uk.gov.hmrc.agentclientauthorisation.audit.AuditService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -30,6 +31,7 @@ class InvitationsStatusUpdateSchedulerISpec
   val metrics = app.injector.instanceOf[Metrics]
   val schedulerRepository = app.injector.instanceOf[MongoScheduleRepository]
   val invitationsRepository = app.injector.instanceOf[InvitationsRepositoryImpl]
+  val auditService = app.injector.instanceOf(classOf[AuditService])
 
   val invitationsService = new InvitationsService(
     invitationsRepository,
@@ -37,6 +39,7 @@ class InvitationsStatusUpdateSchedulerISpec
     analyticsService,
     desConnector,
     emailService,
+    auditService,
     appConfig,
     metrics)
 

--- a/testcommon/uk/gov/hmrc/agentclientauthorisation/support/TestConstants.scala
+++ b/testcommon/uk/gov/hmrc/agentclientauthorisation/support/TestConstants.scala
@@ -38,6 +38,7 @@ object TestConstants {
   val urn = Urn("TRUSTXX10000100")
 
   val arn = "ABCDEF123456"
+  val arn2 = "KARN3869382"
 
   val invitationIds = Seq(InvitationId("ABBBBBBBBBBCA"), InvitationId("ABBBBBBBBBBCB"), InvitationId("ABBBBBBBBBBCC"))
 


### PR DESCRIPTION
- When an invitation request with status `Partialauth` has expired, send an audit event `HmrcExpiredAgentServiceAuthorisation`. These will be picked up via the `RoutineJobScheduler`
- Some refactoring of `RoutineJobSchedulerISpec`:
- use a longer default patience (via `IntegrationPatience`) to allow enough time for the next scheduled job to get picked up in order to get a successful test result.
- Separate out each test case scenario for clarity. 