### PR TITLE
APB-7216 [CS] fix cbc subscription reads

### DIFF
--- a/test/uk/gov/hmrc/agentclientauthorisation/model/SimpleCbcSubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/model/SimpleCbcSubscriptionSpec.scala
@@ -29,11 +29,10 @@ class SimpleCbcSubscriptionSpec extends UnitSpec {
                                                                  |			"processingDate": "2020-08-09T11:23:45Z"
                                                                  |		},
                                                                  |		"responseDetail": {
-                                                                 |			"subscriptionID": "yu789428932",
+                                                                 |			"subscriptionID": "XYCBC2764649410",
                                                                  |			"tradingName": "Tools for Traders",
                                                                  |			"isGBUser": true,
-                                                                 |			"primaryContact": [
-                                                                 |				{
+                                                                 |			"primaryContact": {
                                                                  |					"email": "Tim@toolsfortraders.com",
                                                                  |					"phone": "078803423883",
                                                                  |					"mobile": "078803423883",
@@ -41,16 +40,13 @@ class SimpleCbcSubscriptionSpec extends UnitSpec {
                                                                  |						"lastName": "Taylor",
                                                                  |						"firstName": "Tim"
                                                                  |					}
+                                                                 |			},
+                                                                 |			"secondaryContact": {
+                                                                 |				"email": "contact@toolsfortraders.com",
+                                                                 |				"organisation": {
+                                                                 |					"organisationName": "Tools for Traders Limited"
                                                                  |				}
-                                                                 |			],
-                                                                 |			"secondaryContact": [
-                                                                 |				{
-                                                                 |					"email": "contact@toolsfortraders.com",
-                                                                 |					"organisation": {
-                                                                 |						"organisationName": "Tools for Traders Limited"
-                                                                 |					}
-                                                                 |				}
-                                                                 |			]
+                                                                 |			}
                                                                  |		}
                                                                  |	}
                                                                  |}""".stripMargin).as[JsObject]
@@ -62,7 +58,7 @@ class SimpleCbcSubscriptionSpec extends UnitSpec {
           tradingName = Some("Tools for Traders"),
           otherNames = Seq("Tim Taylor", "Tools for Traders Limited"),
           isGBUser = true,
-          emails = Some(Seq("Tim@toolsfortraders.com", "contact@toolsfortraders.com"))
+          emails = Seq("Tim@toolsfortraders.com", "contact@toolsfortraders.com")
         )
     }
     "return the trading name if available when asked for a name" in {
@@ -70,7 +66,7 @@ class SimpleCbcSubscriptionSpec extends UnitSpec {
         tradingName = Some("Tools for Traders"),
         otherNames = Seq("Tim Taylor", "Tools for Traders Limited"),
         isGBUser = true,
-        emails = None
+        emails = Seq("Tim@toolsfortraders.com", "contact@toolsfortraders.com")
       ).anyAvailableName shouldBe Some("Tools for Traders")
     }
     "return any other available name if the trading name is not available" in {
@@ -78,7 +74,7 @@ class SimpleCbcSubscriptionSpec extends UnitSpec {
         tradingName = None,
         otherNames = Seq("Tim Taylor", "Tools for Traders Limited"),
         isGBUser = true,
-        emails = None
+        emails = Seq("Tim@toolsfortraders.com", "contact@toolsfortraders.com")
       ).anyAvailableName shouldBe Some("Tim Taylor")
     }
   }

--- a/test/uk/gov/hmrc/agentclientauthorisation/service/ClientNameServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/service/ClientNameServiceSpec.scala
@@ -35,23 +35,23 @@ class ClientNameServiceSpec extends UnitSpec with MocksWithCache {
 
   val nino: Nino = Nino("AB123456A")
   val mtdItId: MtdItId = MtdItId("LCLG57411010846")
-  val vrn = Vrn("555219930")
+  val vrn: Vrn = Vrn("555219930")
 
-  val utr = Utr("2134514321")
-  val urn = Utr("AAAAA2642468661")
+  val utr: Utr = Utr("2134514321")
+  val urn: Utr = Utr("AAAAA2642468661")
 
-  val cgtRef = CgtRef("XMCGTP123456789")
-  val cbcId = CbcId("XAPPT001122334455")
-  implicit val hc = HeaderCarrier()
+  val cgtRef: CgtRef = CgtRef("XMCGTP123456789")
+  val cbcId: CbcId = CbcId("XAPPT001122334455")
+  implicit val hc: HeaderCarrier = HeaderCarrier()
 
-  val tpd = TypeOfPersonDetails("Individual", Left(IndividualName("firstName", "lastName")))
-  val tpdBus = TypeOfPersonDetails("Organisation", Right(OrganisationName("Trustee")))
+  val tpd: TypeOfPersonDetails = TypeOfPersonDetails("Individual", Left(IndividualName("firstName", "lastName")))
+  val tpdBus: TypeOfPersonDetails = TypeOfPersonDetails("Organisation", Right(OrganisationName("Trustee")))
 
-  val cgtAddressDetails =
+  val cgtAddressDetails: CgtAddressDetails =
     CgtAddressDetails("line1", Some("line2"), Some("line2"), Some("line2"), "GB", Some("postcode"))
 
-  val cgtSubscription = CgtSubscription("CGT", SubscriptionDetails(tpd, cgtAddressDetails))
-  val cgtSubscriptionBus = CgtSubscription("CGT", SubscriptionDetails(tpdBus, cgtAddressDetails))
+  val cgtSubscription: CgtSubscription = CgtSubscription("CGT", SubscriptionDetails(tpd, cgtAddressDetails))
+  val cgtSubscriptionBus: CgtSubscription = CgtSubscription("CGT", SubscriptionDetails(tpdBus, cgtAddressDetails))
 
   "getClientNameByService" should {
     "get the trading name if the service is ITSA" in {
@@ -166,7 +166,7 @@ class ClientNameServiceSpec extends UnitSpec with MocksWithCache {
       (mockEisConnector
         .getCbcSubscription(_: CbcId)(_: HeaderCarrier, _: ExecutionContext))
         .expects(cbcId, *, *)
-        .returns(Future(Some(SimpleCbcSubscription(Some("Johnson and Oldman"), Seq.empty, true, Some(Seq("email@host.com"))))))
+        .returns(Future(Some(SimpleCbcSubscription(Some("Johnson and Oldman"), Seq.empty, isGBUser = true, Seq.empty))))
 
       val result = await(clientNameService.getClientNameByService(cbcId.value, Service.Cbc))
       result shouldBe Some("Johnson and Oldman")


### PR DESCRIPTION
It’s not 100% clear from the spec if primary and secondary contacts are both required fields.

So far I’ve treated both as required, but we could run into issues down the line if only the primary contact is mandatory.
Also for the known fact check - are we happy if they match either contact email, or should it only be the primary contact?