### PR TITLE
APB-7216 [CS] support client auth for uk cbc

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/AuthActions.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/AuthActions.scala
@@ -248,12 +248,20 @@ class AuthActions @Inject()(metrics: Metrics, appConfig: AppConfig, val authConn
             enrols.enrolments
               .filter(enrol => Service.supportedServices.map(_.enrolmentKey).contains(enrol.key))
               .map { supportedEnrol =>
-                (
-                  supportedServiceName(supportedEnrol.key).getOrElse(
-                    throw new RuntimeException(s"service name not found for supported enrolment $supportedEnrol")),
-                  supportedEnrol.identifiers.head.key,
-                  supportedEnrol.identifiers.head.value.replaceAll(" ", "")
-                )
+                if (supportedEnrol.key == Service.HMRCCBCORG) {
+                  ( // TODO - handle better, multi-identifier lookup? Uk cbc has UTR first
+                    supportedServiceName(supportedEnrol.key).getOrElse(
+                      throw new RuntimeException(s"service name not found for supported enrolment $supportedEnrol")),
+                    supportedEnrol.identifiers.reverse.head.key,
+                    supportedEnrol.identifiers.reverse.head.value.replaceAll(" ", ""))
+                } else {
+                  (
+                    supportedServiceName(supportedEnrol.key).getOrElse(
+                      throw new RuntimeException(s"service name not found for supported enrolment $supportedEnrol")),
+                    supportedEnrol.identifiers.head.key,
+                    supportedEnrol.identifiers.head.value.replaceAll(" ", "")
+                  )
+                }
               }
               .toSeq
 

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsController.scala
@@ -102,7 +102,7 @@ class AgencyInvitationsController @Inject()(
     }
   }
 
-  def getInvitationUrl(givenArn: Arn, clientType: String): Action[AnyContent] = onlyForAgents { implicit request =>implicit arn =>
+  def getInvitationUrl(givenArn: Arn, clientType: String): Action[AnyContent] = onlyForAgents { implicit request => implicit arn =>
     forThisAgency(givenArn) {
       for {
         result <- agentLinkService
@@ -329,7 +329,7 @@ class AgencyInvitationsController @Inject()(
         desConnector.getPptSubscriptionRawJson(pptRef)
       }.map {
         case Some(sub) => Ok(Json.toJson(sub))
-        case None => NotFound
+        case None      => NotFound
       }
     }
   }

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientStatusController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/ClientStatusController.scala
@@ -67,7 +67,7 @@ class ClientStatusController @Inject()(
                    }
       } yield Ok(Json.toJson(status))
     } {
-      Ok(Json.toJson(ClientStatus(false, false, false)))
+      Ok(Json.toJson(ClientStatus(hasPendingInvitations = false, hasInvitationsHistory = false, hasExistingRelationships = false)))
     }
 
   }
@@ -87,6 +87,7 @@ object ClientStatusController {
       .map(i => s"${i._1}__${i._2}".toLowerCase.replaceAllLiterally(" ", ""))
       .mkString(",")
 
-  val defaultClientStatus = Future.successful(ClientStatus(false, false, false))
+  val defaultClientStatus: Future[ClientStatus] =
+    Future.successful(ClientStatus(hasPendingInvitations = false, hasInvitationsHistory = false, hasExistingRelationships = false))
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,7 +6,7 @@ GET         /agencies/:arn/invitations/sent/:invitationId                       
 PUT         /agencies/:arn/invitations/sent/:invitationId/cancel                              @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.cancelInvitation(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn, invitationId: uk.gov.hmrc.agentmtdidentifiers.model.InvitationId)
 
 POST        /invitations/:urn/replace/utr/:utr                                                @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.replaceUrnInvitationWithUtr(urn: uk.gov.hmrc.agentmtdidentifiers.model.Urn, utr: uk.gov.hmrc.agentmtdidentifiers.model.Utr)
-PUT         /invitations/set-relationship-ended                                                 @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.setRelationshipEnded()
+PUT         /invitations/set-relationship-ended                                               @uk.gov.hmrc.agentclientauthorisation.controllers.AgencyInvitationsController.setRelationshipEnded()
 
 GET         /agencies/references/uid/:uid                                                     @uk.gov.hmrc.agentclientauthorisation.controllers.AgentReferenceController.getAgentReferenceRecord(uid: String)
 GET         /agencies/references/arn/:arn                                                     @uk.gov.hmrc.agentclientauthorisation.controllers.AgentReferenceController.getAgentReferenceRecordByArn(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
@@ -30,7 +30,7 @@ PUT         /clients/:clientIdType/:clientId/invitations/received/:invitationId/
 PUT         /clients/:clientIdType/:clientId/invitations/received/:invitationId/reject        @uk.gov.hmrc.agentclientauthorisation.controllers.ClientInvitationsController.rejectInvitation(clientIdType: String, clientId: String, invitationId: uk.gov.hmrc.agentmtdidentifiers.model.InvitationId)
 GET         /clients/:clientIdType/:clientId/invitations/received/:invitationId               @uk.gov.hmrc.agentclientauthorisation.controllers.ClientInvitationsController.getInvitation(clientIdType: String, clientId: String, invitationId: uk.gov.hmrc.agentmtdidentifiers.model.InvitationId)
 
-GET         /clients/:clientIdType/:identifier/invitations/received                                @uk.gov.hmrc.agentclientauthorisation.controllers.ClientInvitationsController.getInvitations(clientIdType: String, identifier: String, status: Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
+GET         /clients/:clientIdType/:identifier/invitations/received                           @uk.gov.hmrc.agentclientauthorisation.controllers.ClientInvitationsController.getInvitations(clientIdType: String, identifier: String, status: Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
 
 GET         /clients/invitations/uid/:uid                                                     @uk.gov.hmrc.agentclientauthorisation.controllers.AgentReferenceController.getInvitationsInfo(uid: String, status:  Option[uk.gov.hmrc.agentclientauthorisation.model.InvitationStatus])
 


### PR DESCRIPTION
Should allow uk cbc clients to view their invitation.

There's still might be some extra changes while I'm looking at agent-client-authorisation.