### PR TITLE
add back messages wrapper to email information

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/service/EmailService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/service/EmailService.scala
@@ -106,7 +106,7 @@ class EmailService @Inject()(
       }
     }
 
-  def emailInformation(templateId: String, agencyEmail: String, agencyName: String, clientName: String, invitation: Invitation) =
+  private def emailInformation(templateId: String, agencyEmail: String, agencyName: String, clientName: String, invitation: Invitation) =
     EmailInformation(
       Seq(agencyEmail),
       templateId,

--- a/app/uk/gov/hmrc/agentclientauthorisation/service/EmailService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/service/EmailService.scala
@@ -106,7 +106,7 @@ class EmailService @Inject()(
       }
     }
 
-  private def emailInformation(templateId: String, agencyEmail: String, agencyName: String, clientName: String, invitation: Invitation) =
+  def emailInformation(templateId: String, agencyEmail: String, agencyName: String, clientName: String, invitation: Invitation) =
     EmailInformation(
       Seq(agencyEmail),
       templateId,

--- a/app/uk/gov/hmrc/agentclientauthorisation/service/EmailService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/service/EmailService.scala
@@ -114,7 +114,7 @@ class EmailService @Inject()(
         "agencyName" -> agencyName,
         "clientName" -> clientName,
         "expiryDate" -> DateUtils.displayDate(invitation.expiryDate),
-        "service"    -> s"service.${invitation.service.id}",
+        "service"    -> messagesApi(s"service.${invitation.service.id}"),
         "additionalInfo" -> {
           if (isAltItsa(invitation))
             s"You must now sign $clientName up to Making Tax Digital for Income Tax."

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,13 +5,13 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
+    <logger name="uk.gov" level="WARN"/>
 
     <logger name="uk.gov.hmrc.audit.handler.DatastreamHandler" level="WARN" />
 
     <logger name="uk.gov.hmrc.clusterworkthrottling" level="INFO"/>
 
-    <root level="${logger.application:-WARN}">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/EmailStub.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/EmailStub.scala
@@ -33,6 +33,16 @@ trait EmailStub {
       )
     }
 
+  def verifyEmailRequestWasSentWithEmailInformation(times: Int, emailInformation: EmailInformation): Unit = {
+    val emailInformationJson = Json.toJson(emailInformation).toString()
+    eventually {
+      verify(
+        times,
+        postRequestedFor(urlPathEqualTo("/hmrc/email"))
+          .withRequestBody(similarToJson(emailInformationJson))
+      )
+    }
+  }
   private def similarToJson(value: String) = equalToJson(value.stripMargin, true, true)
 
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,6 +21,7 @@ object AppDependencies {
     "org.scalatestplus.play" %% "scalatestplus-play"       % "5.1.0"    % "test, it",
     "org.scalatestplus"      %% "mockito-3-12"             % "3.2.10.0" % "test, it",
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % mongoVer   % "test, it",
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28"   % bootstrapVer % "test, it",
     "com.github.tomakehurst" %  "wiremock-jre8"            % "2.26.1"   % "test, it",
     "org.pegdown"            %  "pegdown"                  % "1.6.0"    % "test, it",
     "org.scalamock"          %% "scalamock"                % "5.1.0"    % "test, it",


### PR DESCRIPTION
add back messages wrapper that was removed in June. As a result, emails were being sent without service descriptions.