### PR TITLE
Apb 7583 - iw - Add session id and request id to off-platform requests

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/config/AppConfig.scala
@@ -41,6 +41,7 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig) {
 
   val ifPlatformBaseUrl: String = baseUrl("if")
   val ifEnvironment: String = getConf("if.environment")
+  val ifAuthTokenAPI1171: String = getConf("if.authorization-token.API1171")
   val ifAuthTokenAPI1712: String = getConf("if.authorization-token.API1712")
   val ifAuthTokenAPI1495: String = getConf("if.authorization-token.API1495")
   val ifAuthTokenAPI2143: String = getConf("if.authorization-token.API2143")

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesConnector.scala
@@ -22,7 +22,7 @@ import com.kenshoo.play.metrics.Metrics
 import play.api.Logging
 import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.libs.json.Reads._
-import play.api.libs.json.{JsValue, Writes}
+import play.api.libs.json.Writes
 import play.utils.UriEncoding
 import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
 import uk.gov.hmrc.agentclientauthorisation.UriPathEncoding.encodePathSegment
@@ -30,7 +30,6 @@ import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentclientauthorisation.service.AgentCacheProvider
 import uk.gov.hmrc.agentmtdidentifiers.model._
-import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http._
 
@@ -41,11 +40,7 @@ import scala.util.Try
 @ImplementedBy(classOf[DesConnectorImpl])
 trait DesConnector {
 
-  def getBusinessDetails(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[BusinessDetails]]
-
   def getVatDetails(vrn: Vrn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[VatDetails]]
-  //IF
-  def getTrustName(trustTaxIdentifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustResponse]
 
   def getCgtSubscription(cgtRef: CgtRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[CgtSubscriptionResponse]
 
@@ -53,17 +48,7 @@ trait DesConnector {
 
   def getBusinessName(utr: Utr)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]]
 
-  def getNinoFor(mtdId: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]]
-
-  def getMtdIdFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[MtdItId]]
-
-  def getTradingNameForNino(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]]
-
   def getVatCustomerDetails(vrn: Vrn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[VatCustomerDetails]]
-  //IF
-  def getPptSubscriptionRawJson(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[JsValue]]
-  //IF
-  def getPptSubscription(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PptSubscription]]
 
   def getPillar2Details(plrId: PlrId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Pillar2DetailsResponse]
 
@@ -81,22 +66,6 @@ class DesConnectorImpl @Inject()(
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
   private val baseUrl: String = appConfig.desBaseUrl
-  private val ifBaseUrl: String = appConfig.ifPlatformBaseUrl // TODO split IFConnector
-
-  /* IF API#1171 Get Business Details (for ITSA customers) */
-  def getBusinessDetails(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[BusinessDetails]] = {
-    val url = s"$ifBaseUrl/registration/business-details/nino/${encodePathSegment(nino.value)}"
-    getWithDesIfHeaders("GetRegistrationBusinessDetailsByNino", url, viaIf = true).map { response =>
-      response.status match {
-        case status if is2xx(status) => response.json.asOpt[BusinessDetails]
-        case status if is4xx(status) =>
-          logger.warn(s"4xx response for getBusinessDetails ${response.body}")
-          None
-        case other =>
-          throw UpstreamErrorResponse(s"unexpected error during 'getBusinessDetails', statusCode=$other", other, other)
-      }
-    }
-  }
 
   def getVatDetails(vrn: Vrn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[VatDetails]] = {
     val url = s"$baseUrl/vat/customer/vrn/${encodePathSegment(vrn.value)}/information"
@@ -108,28 +77,6 @@ class DesConnectorImpl @Inject()(
           None
         case other =>
           throw UpstreamErrorResponse(response.body, other, other)
-      }
-    }
-  }
-
-  //IF API#1495 Agent Known Fact Check (Trusts)
-  def getTrustName(trustTaxIdentifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustResponse] = {
-
-    val url = getTrustNameUrl(trustTaxIdentifier, appConfig.desIFEnabled)
-
-    getWithDesIfHeaders("getTrustName", url, appConfig.desIFEnabled).map { response =>
-      response.status match {
-        case status if is2xx(status) =>
-          TrustResponse(Right(TrustName((response.json \ "trustDetails" \ "trustName").as[String])))
-        case status if is4xx(status) =>
-          val invalidTrust = Try(((response.json \ "code").as[String], (response.json \ "reason").as[String])).toEither
-            .fold(ex => {
-              logger.error(s"${response.body}, ${ex.getMessage}")
-              InvalidTrust(status.toString, ex.getMessage)
-            }, t => InvalidTrust(t._1, t._2))
-          TrustResponse(Left(invalidTrust))
-        case other =>
-          throw UpstreamErrorResponse(s"unexpected status during retrieving TrustName, error=${response.body}", other, other)
       }
     }
   }
@@ -235,58 +182,6 @@ class DesConnectorImpl @Inject()(
         }
     }
 
-  /* IF API#1171 Get Business Details (for ITSA customers) */
-  def getNinoFor(mtdId: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]] = {
-    val url = s"$ifBaseUrl/registration/business-details/mtdId/${UriEncoding.encodePathSegment(mtdId.value, "UTF-8")}"
-    agentCacheProvider.clientNinoCache(mtdId.value) {
-      getWithDesIfHeaders("GetRegistrationBusinessDetailsByMtdId", url, viaIf = true).map { response =>
-        response.status match {
-          case status if is2xx(status) => response.json.asOpt[NinoDesResponse].map(_.nino)
-          case status if is4xx(status) =>
-            logger.warn(s"4xx response from getNinoFor ${response.body}")
-            None
-          case other =>
-            throw UpstreamErrorResponse(s"unexpected error during 'getNinoFor', statusCode=$other", other, other)
-        }
-      }
-    }
-  }
-
-  /* IF API#1171 Get Business Details (for ITSA customers) */
-  def getMtdIdFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[MtdItId]] = {
-    val url = s"$ifBaseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
-    agentCacheProvider.clientMtdItIdCache(nino.value) {
-      getWithDesIfHeaders("GetRegistrationBusinessDetailsByNino", url, viaIf = true).map { response =>
-        response.status match {
-          case status if is2xx(status) => response.json.asOpt[MtdItIdIfResponse].map(_.mtdId)
-          case status if is4xx(status) =>
-            logger.warn(s"4xx response from getMtdItIdFor ${response.body}")
-            None
-          case other =>
-            throw UpstreamErrorResponse(s"unexpected error during 'getMtdIdFor', statusCode=$other", other, other)
-        }
-      }
-    }
-  }
-
-  /* IF API#1171 Get Business Details (for ITSA customers) */
-  def getTradingNameForNino(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] = {
-    val url =
-      s"$ifBaseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
-    agentCacheProvider.tradingNameCache(nino.value) {
-      getWithDesIfHeaders("GetTradingNameByNino", url, viaIf = true).map { response =>
-        response.status match {
-          case status if is2xx(status) => (response.json \ "businessData").toOption.map(_(0) \ "tradingName").flatMap(_.asOpt[String])
-          case status if is4xx(status) =>
-            logger.warn(s"4xx response from getTradingNameForNino ${response.body}")
-            None
-          case other =>
-            throw UpstreamErrorResponse(s"unexpected error during 'getTradingNameForNino', statusCode=$other", other, other)
-        }
-      }
-    }
-  }
-
   def getVatCustomerDetails(vrn: Vrn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[VatCustomerDetails]] = {
     val url = s"$baseUrl/vat/customer/vrn/${UriEncoding.encodePathSegment(vrn.value, "UTF-8")}/information"
     agentCacheProvider.vatCustomerDetailsCache(vrn.value) {
@@ -303,28 +198,6 @@ class DesConnectorImpl @Inject()(
       }
     }
   }
-
-  //IF API#1712 PPT Subscription Display
-  def getPptSubscriptionRawJson(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[JsValue]] = {
-    val url = s"$ifBaseUrl/plastic-packaging-tax/subscriptions/PPT/${pptRef.value}/display"
-    agentCacheProvider.pptSubscriptionCache(pptRef.value) {
-      getWithDesIfHeaders("GetPptSubscriptionDisplay", url, viaIf = true).map { response =>
-        response.status match {
-          case status if is2xx(status) =>
-            Some(response.json)
-          case status if is4xx(status) =>
-            logger.warn(s"$status response from getPptSubscriptionDisplay ${response.body}")
-            None
-          case other =>
-            throw UpstreamErrorResponse(s"unexpected error from getPptSubscriptionDisplay, status = $other", other)
-        }
-      }
-    }
-  }
-
-  //IF API#1712 PPT Subscription Display
-  def getPptSubscription(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PptSubscription]] =
-    getPptSubscriptionRawJson(pptRef).map(_.flatMap(_.asOpt[PptSubscription](PptSubscription.reads)))
 
   private def getWithDesIfHeaders(apiName: String, url: String, viaIf: Boolean = false)(
     implicit hc: HeaderCarrier,
@@ -343,11 +216,4 @@ class DesConnectorImpl @Inject()(
         s"$baseUrl/registration/personal-details/utr/$encodedUtr"
     }
 
-  private val utrPattern = "^\\d{10}$"
-
-  private def getTrustNameUrl(trustTaxIdentifier: String, ifEnabled: Boolean): String =
-    if (!ifEnabled) s"$baseUrl/trusts/agent-known-fact-check/$trustTaxIdentifier"
-    else if (trustTaxIdentifier.matches(utrPattern))
-      s"$ifBaseUrl/trusts/agent-known-fact-check/UTR/$trustTaxIdentifier"
-    else s"$ifBaseUrl/trusts/agent-known-fact-check/URN/$trustTaxIdentifier"
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIFConnector.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIFConnector.scala
@@ -53,7 +53,7 @@ trait DesConnector {
 
   def getBusinessName(utr: Utr)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]]
 
-  def getNinoFor(mtdbsa: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]]
+  def getNinoFor(mtdId: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]]
 
   def getMtdIdFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[MtdItId]]
 
@@ -81,10 +81,12 @@ class DesConnectorImpl @Inject()(
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
   private val baseUrl: String = appConfig.desBaseUrl
+  private val ifBaseUrl: String = appConfig.ifPlatformBaseUrl // TODO split IFConnector
 
+  /* IF API#1171 Get Business Details (for ITSA customers) */
   def getBusinessDetails(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[BusinessDetails]] = {
-    val url = s"$baseUrl/registration/business-details/nino/${encodePathSegment(nino.value)}"
-    getWithDesIfHeaders("getRegistrationBusinessDetailsByNino", url).map { response =>
+    val url = s"$ifBaseUrl/registration/business-details/nino/${encodePathSegment(nino.value)}"
+    getWithDesIfHeaders("GetRegistrationBusinessDetailsByNino", url, viaIf = true).map { response =>
       response.status match {
         case status if is2xx(status) => response.json.asOpt[BusinessDetails]
         case status if is4xx(status) =>
@@ -233,10 +235,11 @@ class DesConnectorImpl @Inject()(
         }
     }
 
-  def getNinoFor(mtdbsa: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]] = {
-    val url = s"$baseUrl/registration/business-details/mtdbsa/${UriEncoding.encodePathSegment(mtdbsa.value, "UTF-8")}"
-    agentCacheProvider.clientNinoCache(mtdbsa.value) {
-      getWithDesIfHeaders("GetRegistrationBusinessDetailsByMtdbsa", url).map { response =>
+  /* IF API#1171 Get Business Details (for ITSA customers) */
+  def getNinoFor(mtdId: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]] = {
+    val url = s"$ifBaseUrl/registration/business-details/mtdId/${UriEncoding.encodePathSegment(mtdId.value, "UTF-8")}"
+    agentCacheProvider.clientNinoCache(mtdId.value) {
+      getWithDesIfHeaders("GetRegistrationBusinessDetailsByMtdId", url, viaIf = true).map { response =>
         response.status match {
           case status if is2xx(status) => response.json.asOpt[NinoDesResponse].map(_.nino)
           case status if is4xx(status) =>
@@ -249,12 +252,13 @@ class DesConnectorImpl @Inject()(
     }
   }
 
+  /* IF API#1171 Get Business Details (for ITSA customers) */
   def getMtdIdFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[MtdItId]] = {
-    val url = s"$baseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
+    val url = s"$ifBaseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
     agentCacheProvider.clientMtdItIdCache(nino.value) {
-      getWithDesIfHeaders("GetRegistrationBusinessDetailsByNino", url).map { response =>
+      getWithDesIfHeaders("GetRegistrationBusinessDetailsByNino", url, viaIf = true).map { response =>
         response.status match {
-          case status if is2xx(status) => response.json.asOpt[MtdItIdDesResponse].map(_.mtdbsa)
+          case status if is2xx(status) => response.json.asOpt[MtdItIdIfResponse].map(_.mtdId)
           case status if is4xx(status) =>
             logger.warn(s"4xx response from getMtdItIdFor ${response.body}")
             None
@@ -265,11 +269,12 @@ class DesConnectorImpl @Inject()(
     }
   }
 
+  /* IF API#1171 Get Business Details (for ITSA customers) */
   def getTradingNameForNino(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] = {
     val url =
-      s"$baseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
+      s"$ifBaseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
     agentCacheProvider.tradingNameCache(nino.value) {
-      getWithDesIfHeaders("GetTradingNameByNino", url).map { response =>
+      getWithDesIfHeaders("GetTradingNameByNino", url, viaIf = true).map { response =>
         response.status match {
           case status if is2xx(status) => (response.json \ "businessData").toOption.map(_(0) \ "tradingName").flatMap(_.asOpt[String])
           case status if is4xx(status) =>
@@ -301,9 +306,9 @@ class DesConnectorImpl @Inject()(
 
   //IF API#1712 PPT Subscription Display
   def getPptSubscriptionRawJson(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[JsValue]] = {
-    val url = s"${appConfig.ifPlatformBaseUrl}/plastic-packaging-tax/subscriptions/PPT/${pptRef.value}/display"
+    val url = s"$ifBaseUrl/plastic-packaging-tax/subscriptions/PPT/${pptRef.value}/display"
     agentCacheProvider.pptSubscriptionCache(pptRef.value) {
-      getWithDesIfHeaders("GetPptSubscriptionDisplay", url, true).map { response =>
+      getWithDesIfHeaders("GetPptSubscriptionDisplay", url, viaIf = true).map { response =>
         response.status match {
           case status if is2xx(status) =>
             Some(response.json)
@@ -343,6 +348,6 @@ class DesConnectorImpl @Inject()(
   private def getTrustNameUrl(trustTaxIdentifier: String, ifEnabled: Boolean): String =
     if (!ifEnabled) s"$baseUrl/trusts/agent-known-fact-check/$trustTaxIdentifier"
     else if (trustTaxIdentifier.matches(utrPattern))
-      s"${appConfig.ifPlatformBaseUrl}/trusts/agent-known-fact-check/UTR/$trustTaxIdentifier"
-    else s"${appConfig.ifPlatformBaseUrl}/trusts/agent-known-fact-check/URN/$trustTaxIdentifier"
+      s"$ifBaseUrl/trusts/agent-known-fact-check/UTR/$trustTaxIdentifier"
+    else s"$ifBaseUrl/trusts/agent-known-fact-check/URN/$trustTaxIdentifier"
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeaders.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeaders.scala
@@ -45,8 +45,8 @@ class DesIfHeaders @Inject()(appConfig: AppConfig) extends Logging {
     val baseHeaders = Seq(
       Environment   -> s"${if (viaIF) { ifEnvironment } else { desEnvironment }}",
       CorrelationId -> UUID.randomUUID().toString,
-      SessionId     -> hc.sessionId.toString,
-      RequestId     -> hc.requestId.toString
+      SessionId     -> hc.sessionId.map(_.value).getOrElse(""),
+      RequestId     -> hc.requestId.map(_.value).getOrElse("")
     )
 
     val api1171 = Seq(

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeaders.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeaders.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentclientauthorisation.connectors
 
 import play.api.Logging
 import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
+import uk.gov.hmrc.http.HeaderCarrier
 
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
@@ -27,6 +28,8 @@ class DesIfHeaders @Inject()(appConfig: AppConfig) extends Logging {
 
   private val Environment = "Environment"
   private val CorrelationId = "CorrelationId"
+  private val SessionId = "x-session-id"
+  private val RequestId = "x-request-id"
   private val Authorization = "Authorization"
 
   private lazy val desEnvironment: String = appConfig.desEnvironment
@@ -36,11 +39,13 @@ class DesIfHeaders @Inject()(appConfig: AppConfig) extends Logging {
   private lazy val ifAuthTokenAPI1495: String = appConfig.ifAuthTokenAPI1495
   private lazy val ifAuthTokenAPI2143: String = appConfig.ifAuthTokenAPI2143
 
-  def outboundHeaders(viaIF: Boolean, apiName: Option[String] = None): Seq[(String, String)] = {
+  def outboundHeaders(viaIF: Boolean, apiName: Option[String] = None)(implicit hc: HeaderCarrier): Seq[(String, String)] = {
 
     val baseHeaders = Seq(
       Environment   -> s"${if (viaIF) { ifEnvironment } else { desEnvironment }}",
-      CorrelationId -> UUID.randomUUID().toString
+      CorrelationId -> UUID.randomUUID().toString,
+      SessionId     -> hc.sessionId.toString,
+      RequestId     -> hc.requestId.toString
     )
 
     if (viaIF) {

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeaders.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeaders.scala
@@ -38,6 +38,7 @@ class DesIfHeaders @Inject()(appConfig: AppConfig) extends Logging {
   private lazy val ifAuthTokenAPI1712: String = appConfig.ifAuthTokenAPI1712
   private lazy val ifAuthTokenAPI1495: String = appConfig.ifAuthTokenAPI1495
   private lazy val ifAuthTokenAPI2143: String = appConfig.ifAuthTokenAPI2143
+  private lazy val ifAuthTokenAPI1171: String = appConfig.ifAuthTokenAPI1171
 
   def outboundHeaders(viaIF: Boolean, apiName: Option[String] = None)(implicit hc: HeaderCarrier): Seq[(String, String)] = {
 
@@ -48,11 +49,18 @@ class DesIfHeaders @Inject()(appConfig: AppConfig) extends Logging {
       RequestId     -> hc.requestId.toString
     )
 
+    val api1171 = Seq(
+      "GetRegistrationBusinessDetailsByMtdId",
+      "GetRegistrationBusinessDetailsByNino",
+      "GetTradingNameByNino"
+    )
+
     if (viaIF) {
       apiName.fold(baseHeaders) {
         case "getTrustName"              => baseHeaders :+ Authorization -> s"Bearer $ifAuthTokenAPI1495"
         case "GetPptSubscriptionDisplay" => baseHeaders :+ Authorization -> s"Bearer $ifAuthTokenAPI1712"
         case "getPillar2Subscription"    => baseHeaders :+ Authorization -> s"Bearer $ifAuthTokenAPI2143"
+        case s if api1171.contains(s)    => baseHeaders :+ Authorization -> s"Bearer $ifAuthTokenAPI1171"
         case _ =>
           logger.warn(s"Could not set $Authorization header for IF API '$apiName'")
           baseHeaders

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/IfConnector.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/IfConnector.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.connectors
+
+import com.codahale.metrics.MetricRegistry
+import com.google.inject.ImplementedBy
+import com.kenshoo.play.metrics.Metrics
+import play.api.Logging
+import play.api.libs.json.Reads._
+import play.api.libs.json.JsValue
+import play.utils.UriEncoding
+import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
+import uk.gov.hmrc.agentclientauthorisation.UriPathEncoding.encodePathSegment
+import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
+import uk.gov.hmrc.agentclientauthorisation.model._
+import uk.gov.hmrc.agentclientauthorisation.service.AgentCacheProvider
+import uk.gov.hmrc.agentmtdidentifiers.model._
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http._
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+@ImplementedBy(classOf[IfConnectorImpl])
+trait IfConnector {
+  // FF enabled, formerly DES
+  def getTrustName(trustTaxIdentifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustResponse]
+
+  //IF API#1171
+  def getBusinessDetails(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[BusinessDetails]]
+
+  //IF API#1171
+  def getNinoFor(mtdId: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]]
+
+  //IF API#1171
+  def getMtdIdFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[MtdItId]]
+
+  //IF API#1171
+  def getTradingNameForNino(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]]
+
+  def getPptSubscriptionRawJson(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[JsValue]]
+
+  def getPptSubscription(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PptSubscription]]
+
+}
+
+@Singleton
+class IfConnectorImpl @Inject()(
+  appConfig: AppConfig,
+  agentCacheProvider: AgentCacheProvider,
+  httpClient: HttpClient,
+  metrics: Metrics,
+  desIfHeaders: DesIfHeaders)
+    extends HttpAPIMonitor with IfConnector with HttpErrorFunctions with Logging {
+  override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
+
+  private val ifBaseUrl: String = appConfig.ifPlatformBaseUrl
+
+  /* IF API#1171 Get Business Details (for ITSA customers) */
+  def getBusinessDetails(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[BusinessDetails]] = {
+    val url = s"$ifBaseUrl/registration/business-details/nino/${encodePathSegment(nino.value)}"
+    getWithDesIfHeaders("GetRegistrationBusinessDetailsByNino", url, viaIf = true).map { response =>
+      response.status match {
+        case status if is2xx(status) => (response.json \ "taxPayerDisplayResponse").asOpt[BusinessDetails]
+        case status if is4xx(status) =>
+          logger.warn(s"4xx response for getBusinessDetails ${response.body}")
+          None
+        case other =>
+          throw UpstreamErrorResponse(s"unexpected error during 'getBusinessDetails', statusCode=$other", other, other)
+      }
+    }
+  }
+
+  //IF API#1495 Agent Known Fact Check (Trusts)
+  def getTrustName(trustTaxIdentifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustResponse] = {
+
+    val url = getTrustNameUrl(trustTaxIdentifier, appConfig.desIFEnabled)
+
+    getWithDesIfHeaders("getTrustName", url, appConfig.desIFEnabled).map { response =>
+      response.status match {
+        case status if is2xx(status) =>
+          TrustResponse(Right(TrustName((response.json \ "trustDetails" \ "trustName").as[String])))
+        case status if is4xx(status) =>
+          val invalidTrust = Try(((response.json \ "code").as[String], (response.json \ "reason").as[String])).toEither
+            .fold(ex => {
+              logger.error(s"${response.body}, ${ex.getMessage}")
+              InvalidTrust(status.toString, ex.getMessage)
+            }, t => InvalidTrust(t._1, t._2))
+          TrustResponse(Left(invalidTrust))
+        case other =>
+          throw UpstreamErrorResponse(s"unexpected status during retrieving TrustName, error=${response.body}", other, other)
+      }
+    }
+  }
+
+  /* Get Business Details (for ITSA customers) */
+  def getNinoFor(mtdId: MtdItId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Nino]] = {
+    val url = s"$ifBaseUrl/registration/business-details/mtdId/${UriEncoding.encodePathSegment(mtdId.value, "UTF-8")}"
+    agentCacheProvider.clientNinoCache(mtdId.value) {
+      getWithDesIfHeaders("GetRegistrationBusinessDetailsByMtdId", url, viaIf = true).map { response =>
+        response.status match {
+          case status if is2xx(status) => (response.json \ "taxPayerDisplayResponse").asOpt[NinoDesResponse].map(_.nino)
+          case status if is4xx(status) =>
+            logger.warn(s"4xx response from getNinoFor ${response.body}")
+            None
+          case other =>
+            throw UpstreamErrorResponse(s"unexpected error during 'getNinoFor', statusCode=$other", other, other)
+        }
+      }
+    }
+  }
+
+  /* IF API#1171 Get Business Details (for ITSA customers) */
+  def getMtdIdFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[MtdItId]] = {
+    val url = s"$ifBaseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
+    agentCacheProvider.clientMtdItIdCache(nino.value) {
+      getWithDesIfHeaders("GetRegistrationBusinessDetailsByNino", url, viaIf = true).map { response =>
+        response.status match {
+          case status if is2xx(status) => (response.json \ "taxPayerDisplayResponse").asOpt[MtdItIdIfResponse].map(_.mtdId)
+          case status if is4xx(status) =>
+            logger.warn(s"4xx response from getMtdItIdFor ${response.body}")
+            None
+          case other =>
+            throw UpstreamErrorResponse(s"unexpected error during 'getMtdIdFor', statusCode=$other", other, other)
+        }
+      }
+    }
+  }
+
+  /* IF API#1171 Get Business Details (for ITSA customers) */
+  def getTradingNameForNino(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] = {
+    val url =
+      s"$ifBaseUrl/registration/business-details/nino/${UriEncoding.encodePathSegment(nino.value, "UTF-8")}"
+    agentCacheProvider.tradingNameCache(nino.value) {
+      getWithDesIfHeaders("GetTradingNameByNino", url, viaIf = true).map { response =>
+        response.status match {
+          case status if is2xx(status) =>
+            (response.json \ "taxPayerDisplayResponse" \ "businessData").toOption.map(_(0) \ "tradingName").flatMap(_.asOpt[String])
+          case status if is4xx(status) =>
+            logger.warn(s"4xx response from getTradingNameForNino ${response.body}")
+            None
+          case other =>
+            throw UpstreamErrorResponse(s"unexpected error during 'getTradingNameForNino', statusCode=$other", other, other)
+        }
+      }
+    }
+  }
+
+  //IF API#1712 PPT Subscription Display
+  def getPptSubscriptionRawJson(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[JsValue]] = {
+    val url = s"$ifBaseUrl/plastic-packaging-tax/subscriptions/PPT/${pptRef.value}/display"
+    agentCacheProvider.pptSubscriptionCache(pptRef.value) {
+      getWithDesIfHeaders("GetPptSubscriptionDisplay", url, viaIf = true).map { response =>
+        response.status match {
+          case status if is2xx(status) =>
+            Some(response.json)
+          case status if is4xx(status) =>
+            logger.warn(s"$status response from getPptSubscriptionDisplay ${response.body}")
+            None
+          case other =>
+            throw UpstreamErrorResponse(s"unexpected error from getPptSubscriptionDisplay, status = $other", other)
+        }
+      }
+    }
+  }
+
+  //IF API#1712 PPT Subscription Display
+  def getPptSubscription(pptRef: PptRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PptSubscription]] =
+    getPptSubscriptionRawJson(pptRef).map(_.flatMap(_.asOpt[PptSubscription](PptSubscription.reads)))
+
+  private def getWithDesIfHeaders(apiName: String, url: String, viaIf: Boolean)(
+    implicit hc: HeaderCarrier,
+    ec: ExecutionContext): Future[HttpResponse] =
+    monitor(s"ConsumedAPI-IF-$apiName-GET") {
+      httpClient.GET[HttpResponse](url, headers = desIfHeaders.outboundHeaders(viaIf, Some(apiName)))(implicitly[HttpReads[HttpResponse]], hc, ec)
+    }
+
+  private val utrPattern = "^\\d{10}$"
+
+  private def getTrustNameUrl(trustTaxIdentifier: String, ifEnabled: Boolean): String =
+    if (!ifEnabled) s"${appConfig.desBaseUrl}/trusts/agent-known-fact-check/$trustTaxIdentifier"
+    else if (trustTaxIdentifier.matches(utrPattern))
+      s"$ifBaseUrl/trusts/agent-known-fact-check/UTR/$trustTaxIdentifier"
+    else s"$ifBaseUrl/trusts/agent-known-fact-check/URN/$trustTaxIdentifier"
+}

--- a/app/uk/gov/hmrc/agentclientauthorisation/connectors/RelationshipsConnector.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/connectors/RelationshipsConnector.scala
@@ -44,11 +44,11 @@ class RelationshipsConnector @Inject()(appConfig: AppConfig, http: HttpClient, m
   private val baseUrl: String = appConfig.relationshipsBaseUrl
   private val afiBaseUrl: String = appConfig.afiRelationshipsBaseUrl
 
-  implicit class FutureResponseOps(f: Future[HttpResponse]) {
-    def handleNon2xx(msg: String)(implicit ec: ExecutionContext): Future[Unit] = f.map { response =>
+  private implicit class FutureResponseOps(f: Future[HttpResponse]) {
+    def handleNon2xx(method: String)(implicit ec: ExecutionContext): Future[Unit] = f.map { response =>
       response.status match {
         case status if is2xx(status) => ()
-        case other                   => throw UpstreamErrorResponse(msg, other)
+        case other                   => throw UpstreamErrorResponse(s"Unexpected status $other received by '$method'", other)
       }
     }
   }
@@ -57,14 +57,14 @@ class RelationshipsConnector @Inject()(appConfig: AppConfig, http: HttpClient, m
     monitor(s"ConsumedAPI-AgentClientRelationships-relationships-MTD-IT-PUT") {
       http
         .PUT[String, HttpResponse](mtdItRelationshipUrl(invitation), "")
-        .handleNon2xx(s"unexpected error during 'createMtdItRelationship'")
+        .handleNon2xx(s"createMtdItRelationship")
     }
 
   def createMtdVatRelationship(invitation: Invitation)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
     monitor(s"ConsumedAPI-AgentClientRelationships-relationships-MTD-VAT-PUT") {
       http
         .PUT[String, HttpResponse](mtdVatRelationshipUrl(invitation), "")
-        .handleNon2xx(s"unexpected error during 'createMtdVatRelationship'")
+        .handleNon2xx(s"createMtdVatRelationship")
     }
 
   def createAfiRelationship(invitation: Invitation, acceptedDate: LocalDateTime)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
@@ -72,7 +72,7 @@ class RelationshipsConnector @Inject()(appConfig: AppConfig, http: HttpClient, m
     monitor(s"ConsumedAPI-AgentFiRelationship-relationships-${invitation.service.id}-PUT") {
       http
         .PUT[JsObject, HttpResponse](afiRelationshipUrl(invitation), body)
-        .handleNon2xx("unexpected error during 'createAfiRelationship'")
+        .handleNon2xx("createAfiRelationship")
     }
   }
 
@@ -80,35 +80,35 @@ class RelationshipsConnector @Inject()(appConfig: AppConfig, http: HttpClient, m
     monitor(s"ConsumedAPI-AgentClientRelationships-relationships-Trust-PUT") {
       http
         .PUT[String, HttpResponse](trustRelationshipUrl(invitation), "")
-        .handleNon2xx("unexpected error during 'createTrustRelationship")
+        .handleNon2xx("createTrustRelationship")
     }
 
   def createCapitalGainsRelationship(invitation: Invitation)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
     monitor(s"ConsumedAPI-AgentClientRelationships-relationships-CapitalGains-PUT") {
       http
         .PUT[String, HttpResponse](cgtRelationshipUrl(invitation), "")
-        .handleNon2xx("unexpected error during 'createCapitalGainsRelationship'")
+        .handleNon2xx("createCapitalGainsRelationship")
     }
 
   def createPlasticPackagingTaxRelationship(invitation: Invitation)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
     monitor(s"ConsumedAPI-AgentClientRelationships-relationships-PlasticPackagingTax-PUT") {
       http
         .PUT[String, HttpResponse](pptRelationshipUrl(invitation), "")
-        .handleNon2xx("unexepected error during 'createPlasticPackagingTaxRelationship'")
+        .handleNon2xx("createPlasticPackagingTaxRelationship")
     }
 
   def createCountryByCountryRelationship(invitation: Invitation)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
     monitor(s"ConsumedAPI-AgentClientRelationships-relationships-CountryByCountry-PUT") {
       http
         .PUT[String, HttpResponse](cbcRelationshipUrl(invitation), "")
-        .handleNon2xx("unexepected error during 'createCountryByCountryRelationship'")
+        .handleNon2xx("createCountryByCountryRelationship")
     }
 
   def createPillar2Relationship(invitation: Invitation)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
     monitor(s"ConsumedAPI-AgentClientRelationships-relationships-Pillar2-PUT") {
       http
         .PUT[String, HttpResponse](pillar2RelationshipUrl(invitation), "")
-        .handleNon2xx("unexepected error during 'createPillar2Relationship'")
+        .handleNon2xx("createPillar2Relationship")
     }
 
   def getActiveRelationships(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Map[String, Seq[Arn]]]] =

--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgentServicesController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgentServicesController.scala
@@ -21,7 +21,7 @@ import play.api.Environment
 import play.api.libs.json.{JsValue, Json, OFormat}
 import play.api.mvc._
 import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
-import uk.gov.hmrc.agentclientauthorisation.connectors.{AuthActions, CitizenDetailsConnector, DesConnector, EisConnector}
+import uk.gov.hmrc.agentclientauthorisation.connectors.{AuthActions, CitizenDetailsConnector, DesConnector, EisConnector, IfConnector}
 import uk.gov.hmrc.agentclientauthorisation.controllers.AgentServicesController.{AgencyNameByArn, AgencyNameByUtr}
 import uk.gov.hmrc.agentclientauthorisation.service.BusinessNamesService
 import uk.gov.hmrc.agentmtdidentifiers.model._
@@ -38,6 +38,7 @@ class AgentServicesController @Inject()(
   override val authConnector: AuthConnector,
   val env: Environment,
   desConnector: DesConnector,
+  ifConnector: IfConnector,
   cidConnector: CitizenDetailsConnector,
   eisConnector: EisConnector,
   businessNamesService: BusinessNamesService,
@@ -169,7 +170,7 @@ class AgentServicesController @Inject()(
 
   def getNinoForMtdItId(mtdItId: MtdItId): Action[AnyContent] = Action.async { implicit request =>
     withBasicAuth {
-      desConnector
+      ifConnector
         .getNinoFor(mtdItId)
         .map {
           case Some(nino) => Ok(Json.obj("nino" -> nino.value))
@@ -182,7 +183,7 @@ class AgentServicesController @Inject()(
 
   def getMtdItIdForNino(nino: Nino): Action[AnyContent] = Action.async { implicit request =>
     withBasicAuth {
-      desConnector
+      ifConnector
         .getMtdIdFor(nino)
         .map {
           case Some(mtdItId) => Ok(Json.obj("mtdItId" -> mtdItId.value))
@@ -195,7 +196,7 @@ class AgentServicesController @Inject()(
 
   def getTradingNameForNino(nino: Nino): Action[AnyContent] = Action.async { implicit request =>
     withBasicAuth {
-      desConnector
+      ifConnector
         .getTradingNameForNino(nino)
         .flatMap {
           case Some(tn) => Future successful Ok(Json.obj("tradingName" -> tn))
@@ -227,7 +228,7 @@ class AgentServicesController @Inject()(
   }
 
   def getPptCustomerName(pptRef: PptRef): Action[AnyContent] = Action.async { implicit request =>
-    desConnector.getPptSubscription(pptRef).map {
+    ifConnector.getPptSubscription(pptRef).map {
       case Some(record) => Ok(Json.obj("customerName" -> record.customerName))
       case None =>
         logger.warn(s"PPT customer not found for getPptCustomerName")

--- a/app/uk/gov/hmrc/agentclientauthorisation/model/BusinessDetails.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/BusinessDetails.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.Json.reads
 import play.api.libs.json.Reads
 import uk.gov.hmrc.agentmtdidentifiers.model.MtdItId
 
-case class BusinessDetails(businessData: Seq[BusinessData], mtdbsa: Option[MtdItId])
+case class BusinessDetails(businessData: Seq[BusinessData], mtdId: Option[MtdItId])
 
 case class BusinessData(businessAddressDetails: Option[BusinessAddressDetails])
 

--- a/app/uk/gov/hmrc/agentclientauthorisation/model/MtdItIdIfResponse.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/MtdItIdIfResponse.scala
@@ -19,10 +19,10 @@ package uk.gov.hmrc.agentclientauthorisation.model
 import play.api.libs.json.{Json, Reads}
 import uk.gov.hmrc.agentmtdidentifiers.model.MtdItId
 
-case class MtdItIdDesResponse(mtdbsa: MtdItId)
+case class MtdItIdIfResponse(mtdId: MtdItId)
 
 case class MtdItIdNotFound() extends Exception
 
-object MtdItIdDesResponse {
-  implicit val reads: Reads[MtdItIdDesResponse] = Json.reads
+object MtdItIdIfResponse {
+  implicit val reads: Reads[MtdItIdIfResponse] = Json.reads
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/service/InvitationsService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/service/InvitationsService.scala
@@ -63,7 +63,7 @@ class InvitationsService @Inject()(
       case MtdItIdType.id => Future successful Some(MtdItId(clientId))
       case NinoType.id =>
         desConnector.getBusinessDetails(Nino(clientId)).map {
-          case Some(record) => record.mtdbsa.map(ClientIdentifier(_))
+          case Some(record) => record.mtdId.map(ClientIdentifier(_))
           case None         => if (appConfig.altItsaEnabled && Nino.isValid(clientId)) Some(ClientIdentifier(clientId, clientIdType)) else None
         }
       case _ => Future successful None
@@ -162,10 +162,9 @@ class InvitationsService @Inject()(
         updateAltItsaFor(Nino(ninoClientId._3)) //if there is an alt-itsa invitation then we want to update it with MTDITID
           .flatMap(_ => findInvitationsInfoBy(arn, clientIds, status))
           .recoverWith {
-            case e: UpstreamErrorResponse => {
+            case e: UpstreamErrorResponse =>
               logger.warn(s"failure when updating alt-Itsa invitations, falling back to existing client data ${e.message}")
               findInvitationsInfoBy(arn, clientIds, status)
-            }
           }
       case _ => findInvitationsInfoBy(arn, clientIds, status)
     }

--- a/app/uk/gov/hmrc/agentclientauthorisation/service/PostcodeService.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/service/PostcodeService.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentclientauthorisation.service
 
 import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.agentclientauthorisation.connectors.DesConnector
+import uk.gov.hmrc.agentclientauthorisation.connectors.IfConnector
 import uk.gov.hmrc.agentclientauthorisation.controllers.ErrorResults._
 import uk.gov.hmrc.agentclientauthorisation.model.BusinessDetails
 import uk.gov.hmrc.agentclientauthorisation.service.PostcodeService.normalise
@@ -28,7 +28,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class PostcodeService @Inject()(desConnector: DesConnector) {
+class PostcodeService @Inject()(ifConnector: IfConnector) {
 
   private val postcodeWithoutSpacesRegex = "^[A-Za-z]{1,2}[0-9]{1,2}[A-Za-z]?[0-9][A-Za-z]{2}$".r
 
@@ -51,7 +51,7 @@ class PostcodeService @Inject()(desConnector: DesConnector) {
     def isUkAddress(details: BusinessDetails) =
       details.businessData.head.businessAddressDetails.map(_.countryCode.toUpperCase).contains("GB")
 
-    desConnector.getBusinessDetails(Nino(clientIdentifier)).flatMap {
+    ifConnector.getBusinessDetails(Nino(clientIdentifier)).flatMap {
       case Some(details) if details.businessData.length != 1                           => failure(PostcodeDoesNotMatch)
       case Some(details) if postcodeMatches(details, postcode) && isUkAddress(details) => ().toFuture
       case Some(details) if postcodeMatches(details, postcode) =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -145,6 +145,7 @@ microservice {
           port = 9904
           environment = test
           authorization-token {
+            API1171 = secret
             API1712 = secret
             API1495 = secret
             API2143 = secret

--- a/it/uk/gov/hmrc/agentclientauthorisation/connectors/DesConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/connectors/DesConnectorISpec.scala
@@ -20,77 +20,13 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants._
 import uk.gov.hmrc.agentclientauthorisation.support.{AppAndStubs, DesStubs, UnitSpec}
-import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, PlrId, PptRef, SuspensionDetails, Vrn}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, PlrId, SuspensionDetails, Vrn}
 import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
-
-  "getBusinessDetails" should {
-    "return postcode and country code for a registered client" in {
-      hasABusinessPartnerRecord(nino)
-
-      val response = await(connector.getBusinessDetails(nino)).get
-
-      response.businessData.head.businessAddressDetails.map(_.countryCode) shouldBe Some("GB")
-      response.businessData.head.businessAddressDetails.flatMap(_.postalCode) shouldBe Some("AA11AA")
-      response.mtdId shouldBe None
-      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetRegistrationBusinessDetailsByNino-GET")
-    }
-
-    "return None if the client is not registered" in {
-      hasNoBusinessPartnerRecord(nino)
-
-      val response = await(connector.getBusinessDetails(nino))
-
-      response shouldBe None
-    }
-  }
-
-  "getNinoFor(MtdId)" should {
-
-    "return nino" in {
-      givenNinoForMtdItId(mtdItId1, nino)
-
-      val response = await(connector.getNinoFor(mtdItId1)).get
-
-      response.nino shouldBe nino.value
-      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetRegistrationBusinessDetailsByMtdId-GET")
-    }
-
-    "return None if not found" in {
-      givenNinoIsUnknownFor(mtdItId1)
-
-      val response = await(connector.getNinoFor(mtdItId1))
-
-      response shouldBe None
-    }
-
-  }
-
-  "getMtdItId" should {
-    "return mtdItId for a registered client" in {
-      hasABusinessPartnerRecordWithMtdItId(nino, mtdItId1)
-
-      val response = await(connector.getBusinessDetails(nino)).get
-
-      response.businessData.head.businessAddressDetails.map(_.countryCode) shouldBe Some("GB")
-      response.businessData.head.businessAddressDetails.flatMap(_.postalCode) shouldBe Some("AA11AA")
-      response.mtdId shouldBe Some(mtdItId1)
-      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetRegistrationBusinessDetailsByNino-GET")
-    }
-
-    "return mtdItId if the business data is empty" in {
-      hasBusinessPartnerRecordWithEmptyBusinessData(nino, mtdItId1)
-
-      val response = await(connector.getBusinessDetails(nino)).get
-
-      response.businessData.length shouldBe 0
-      response.mtdId shouldBe Some(mtdItId1)
-    }
-  }
 
   "getVatCustomerInformation" should {
     val clientVrn = Vrn("101747641")
@@ -260,25 +196,6 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
     }
   }
 
-  "GetTrustName" should {
-    "return the name of a trust for a given Utr" in {
-
-      getTrustName(utr.value, 200, """{"trustDetails": {"trustName": "Nelson James Trust"}}""")
-
-      val result = await(connector.getTrustName(utr.value))
-      result shouldBe TrustResponse(Right(TrustName("Nelson James Trust")))
-      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-getTrustName-GET")
-    }
-
-    "return InvalidTrust response when 400" in {
-
-      getTrustName(utr.value, 400,  """{"code": "INVALID_TRUST_STATE","reason": "The remote endpoint has indicated that the Trust/Estate is Closed and playback is not possible."}""")
-
-      val result = await(connector.getTrustName(utr.value))
-      result shouldBe TrustResponse(Left(InvalidTrust("INVALID_TRUST_STATE", "The remote endpoint has indicated that the Trust/Estate is Closed and playback is not possible.")))
-    }
-  }
-
   "GetAgencyDetails" should {
     "return agency details for a given ARN" in {
 
@@ -309,58 +226,6 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
       val result = await(connector.getAgencyDetails(Right(Arn(arn))))
 
       result shouldBe Some(AgentDetailsDesResponse(None, None))
-    }
-  }
-
-  "getPPTSubscription" should {
-    "return a PPT subscription record" in {
-      givenPptSubscription(PptRef("XAPPT1234567890"), isIndividual = true, deregisteredDetailsPresent = true, isDeregistered = false)
-      val result = connector.getPptSubscription(PptRef("XAPPT1234567890")).futureValue
-      result shouldBe Some(PptSubscription("Bill Sikes", LocalDate.parse("2021-10-12"), Some(LocalDate.parse("2050-10-01"))))
-      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetPptSubscriptionDisplay-GET")
-    }
-    "return None when IF responds with 4xx" in {
-      givenPptSubscriptionRespondsWith(PptRef("XAPPT1234567890"), 404)
-      val result = connector.getPptSubscription(PptRef("XAPPT1234567890")).futureValue
-      result shouldBe None
-    }
-
-    "throw an exception when IF responds with 5xx" in {
-      givenPptSubscriptionRespondsWith(PptRef("XAPPT1234567890"), 503)
-      assertThrows[UpstreamErrorResponse]{
-        await(connector.getPptSubscription(PptRef("XAPPT1234567890")))
-      }
-    }
-  }
-
-  "getTradingNameForNino" should {
-      "return tradingName if defined in businessData" in {
-        hasABusinessPartnerRecord(nino)
-        val result = connector.getTradingNameForNino(nino).futureValue
-        result shouldBe Some("Surname DADTN")
-      }
-    "return None when no businessData is defined" in {
-      hasBusinessPartnerRecordWithNoBusinessData(nino)
-      val result = connector.getTradingNameForNino(nino).futureValue
-      result shouldBe None
-    }
-    "return None when no tradingName is defined within businessData" in {
-      hasABusinessPartnerRecordWithBusinessDataWithNoTradingName(nino)
-      val result = connector.getTradingNameForNino(nino).futureValue
-      result shouldBe None
-    }
-
-    "return None when the Nino is not found" in {
-      hasNoBusinessPartnerRecord(nino)
-      val result = connector.getTradingNameForNino(nino).futureValue
-      result shouldBe None
-    }
-
-    "throw an exception when DES returns a 5xx response" in {
-      assertThrows[UpstreamErrorResponse]{
-        businessPartnerRecordFails(nino, 503)
-        await(connector.getTradingNameForNino(nino))
-      }
     }
   }
 

--- a/it/uk/gov/hmrc/agentclientauthorisation/connectors/DesConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/connectors/DesConnectorISpec.scala
@@ -36,8 +36,8 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
 
       response.businessData.head.businessAddressDetails.map(_.countryCode) shouldBe Some("GB")
       response.businessData.head.businessAddressDetails.flatMap(_.postalCode) shouldBe Some("AA11AA")
-      response.mtdbsa shouldBe None
-      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-getRegistrationBusinessDetailsByNino-GET")
+      response.mtdId shouldBe None
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetRegistrationBusinessDetailsByNino-GET")
     }
 
     "return None if the client is not registered" in {
@@ -49,6 +49,27 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
     }
   }
 
+  "getNinoFor(MtdId)" should {
+
+    "return nino" in {
+      givenNinoForMtdItId(mtdItId1, nino)
+
+      val response = await(connector.getNinoFor(mtdItId1)).get
+
+      response.nino shouldBe nino.value
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetRegistrationBusinessDetailsByMtdId-GET")
+    }
+
+    "return None if not found" in {
+      givenNinoIsUnknownFor(mtdItId1)
+
+      val response = await(connector.getNinoFor(mtdItId1))
+
+      response shouldBe None
+    }
+
+  }
+
   "getMtdItId" should {
     "return mtdItId for a registered client" in {
       hasABusinessPartnerRecordWithMtdItId(nino, mtdItId1)
@@ -57,8 +78,8 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
 
       response.businessData.head.businessAddressDetails.map(_.countryCode) shouldBe Some("GB")
       response.businessData.head.businessAddressDetails.flatMap(_.postalCode) shouldBe Some("AA11AA")
-      response.mtdbsa shouldBe Some(mtdItId1)
-      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-getRegistrationBusinessDetailsByNino-GET")
+      response.mtdId shouldBe Some(mtdItId1)
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetRegistrationBusinessDetailsByNino-GET")
     }
 
     "return mtdItId if the business data is empty" in {
@@ -67,7 +88,7 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
       val response = await(connector.getBusinessDetails(nino)).get
 
       response.businessData.length shouldBe 0
-      response.mtdbsa shouldBe Some(mtdItId1)
+      response.mtdId shouldBe Some(mtdItId1)
     }
   }
 
@@ -85,7 +106,7 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
       }
 
       "effectiveRegistrationDate is present and customer is insolvent" in {
-        hasVatCustomerDetails(clientVrn, Some("2017-04-01"), true)
+        hasVatCustomerDetails(clientVrn, Some("2017-04-01"), isInsolvent = true)
 
         val vatCustomerInfo = await(connector.getVatDetails(clientVrn)).get
         vatCustomerInfo.effectiveRegistrationDate shouldBe Some(LocalDate.parse("2017-04-01"))
@@ -160,7 +181,7 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
       }
 
       "effectiveRegistrationDate is present  and customer is inactive" in {
-        hasPillar2CustomerDetails(clientPlrId, "2017-04-01", true)
+        hasPillar2CustomerDetails(clientPlrId, "2017-04-01", inactive = true)
         val pillar2CustomerInfo = await(connector.getPillar2Details(clientPlrId)).response.right.get
         pillar2CustomerInfo.effectiveRegistrationDate shouldBe LocalDate.parse("2017-04-01")
         pillar2CustomerInfo.inactive shouldBe true
@@ -293,7 +314,7 @@ class DesConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
 
   "getPPTSubscription" should {
     "return a PPT subscription record" in {
-      givenPptSubscription(PptRef("XAPPT1234567890"), true, true, false)
+      givenPptSubscription(PptRef("XAPPT1234567890"), isIndividual = true, deregisteredDetailsPresent = true, isDeregistered = false)
       val result = connector.getPptSubscription(PptRef("XAPPT1234567890")).futureValue
       result shouldBe Some(PptSubscription("Bill Sikes", LocalDate.parse("2021-10-12"), Some(LocalDate.parse("2050-10-01"))))
       verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-GetPptSubscriptionDisplay-GET")

--- a/it/uk/gov/hmrc/agentclientauthorisation/connectors/IfConnectorEnabledISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/connectors/IfConnectorEnabledISpec.scala
@@ -8,7 +8,7 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{TrustTaxIdentifier, Urn, Utr}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DesConnectorIFEnabledISpec extends UnitSpec with AppAndStubs {
+class IfConnectorEnabledISpec extends UnitSpec with AppAndStubs {
 
   override protected def additionalConfiguration =
     super.additionalConfiguration ++  Map(
@@ -21,7 +21,7 @@ class DesConnectorIFEnabledISpec extends UnitSpec with AppAndStubs {
   val utr = Utr("0123456789")
   val urn = Urn("XXTRUST12345678")
 
-  def connector = app.injector.instanceOf[DesConnector]
+  def connector = app.injector.instanceOf[IfConnector]
 
 "API 1495 Get Trust Name with IF enabled" should {
   "have correct headers and call IF selecting the correct url when passed a UTR " in {
@@ -29,7 +29,7 @@ class DesConnectorIFEnabledISpec extends UnitSpec with AppAndStubs {
     val result = await(connector.getTrustName(utr.value))
 
     result shouldBe TrustResponse(Right(TrustName("Nelson James Trust")))
-    verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-getTrustName-GET")
+    verifyTimerExistsAndBeenUpdated("ConsumedAPI-IF-getTrustName-GET")
   }
 
   "have correct headers and call IF selecting the correct url when passed a URN " in {
@@ -37,7 +37,7 @@ class DesConnectorIFEnabledISpec extends UnitSpec with AppAndStubs {
     val result = await(connector.getTrustName(urn.value))
 
     result shouldBe TrustResponse(Right(TrustName("Nelson James Trust")))
-    verifyTimerExistsAndBeenUpdated("ConsumedAPI-DES-getTrustName-GET")
+    verifyTimerExistsAndBeenUpdated("ConsumedAPI-IF-getTrustName-GET")
   }
 }
   private val trustNameJson = """{"trustDetails": {"trustName": "Nelson James Trust"}}"""

--- a/it/uk/gov/hmrc/agentclientauthorisation/connectors/IfConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/connectors/IfConnectorISpec.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.connectors
+
+import play.api.test.Helpers._
+import uk.gov.hmrc.agentclientauthorisation.model._
+import uk.gov.hmrc.agentclientauthorisation.support.TestConstants._
+import uk.gov.hmrc.agentclientauthorisation.support.{AppAndStubs, DesStubs, UnitSpec}
+import uk.gov.hmrc.agentmtdidentifiers.model._
+import uk.gov.hmrc.http.UpstreamErrorResponse
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class IfConnectorISpec extends UnitSpec with AppAndStubs with DesStubs {
+
+  "getBusinessDetails" should {
+    "return postcode and country code for a registered client" in {
+      hasABusinessPartnerRecord(nino)
+
+      val response = await(connector.getBusinessDetails(nino)).get
+
+      response.businessData.head.businessAddressDetails.map(_.countryCode) shouldBe Some("GB")
+      response.businessData.head.businessAddressDetails.flatMap(_.postalCode) shouldBe Some("AA11AA")
+      response.mtdId shouldBe None
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-IF-GetRegistrationBusinessDetailsByNino-GET")
+    }
+
+    "return None if the client is not registered" in {
+      hasNoBusinessPartnerRecord(nino)
+
+      val response = await(connector.getBusinessDetails(nino))
+
+      response shouldBe None
+    }
+  }
+
+  "getNinoFor(MtdId)" should {
+
+    "return nino" in {
+      givenNinoForMtdItId(mtdItId1, nino)
+
+      val response = await(connector.getNinoFor(mtdItId1)).get
+
+      response.nino shouldBe nino.value
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-IF-GetRegistrationBusinessDetailsByMtdId-GET")
+    }
+
+    "return None if not found" in {
+      givenNinoIsUnknownFor(mtdItId1)
+
+      val response = await(connector.getNinoFor(mtdItId1))
+
+      response shouldBe None
+    }
+
+  }
+
+  "getMtdItId" should {
+    "return mtdItId for a registered client" in {
+      hasABusinessPartnerRecordWithMtdItId(nino, mtdItId1)
+
+      val response = await(connector.getBusinessDetails(nino)).get
+
+      response.businessData.head.businessAddressDetails.map(_.countryCode) shouldBe Some("GB")
+      response.businessData.head.businessAddressDetails.flatMap(_.postalCode) shouldBe Some("AA11AA")
+      response.mtdId shouldBe Some(mtdItId1)
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-IF-GetRegistrationBusinessDetailsByNino-GET")
+    }
+
+    "return mtdItId if the business data is empty" in {
+      hasBusinessPartnerRecordWithEmptyBusinessData(nino, mtdItId1)
+
+      val response = await(connector.getBusinessDetails(nino)).get
+
+      response.businessData.length shouldBe 0
+      response.mtdId shouldBe Some(mtdItId1)
+    }
+  }
+
+  "GetTrustName" should {
+    "return the name of a trust for a given Utr" in {
+
+      getTrustName(utr.value, 200, """{"trustDetails": {"trustName": "Nelson James Trust"}}""")
+
+      val result = await(connector.getTrustName(utr.value))
+      result shouldBe TrustResponse(Right(TrustName("Nelson James Trust")))
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-IF-getTrustName-GET")
+    }
+
+    "return InvalidTrust response when 400" in {
+
+      getTrustName(utr.value, 400,  """{"code": "INVALID_TRUST_STATE","reason": "The remote endpoint has indicated that the Trust/Estate is Closed and playback is not possible."}""")
+
+      val result = await(connector.getTrustName(utr.value))
+      result shouldBe TrustResponse(Left(InvalidTrust("INVALID_TRUST_STATE", "The remote endpoint has indicated that the Trust/Estate is Closed and playback is not possible.")))
+    }
+  }
+
+  "getPPTSubscription" should {
+    "return a PPT subscription record" in {
+      givenPptSubscription(PptRef("XAPPT1234567890"), isIndividual = true, deregisteredDetailsPresent = true, isDeregistered = false)
+      val result = connector.getPptSubscription(PptRef("XAPPT1234567890")).futureValue
+      result shouldBe Some(PptSubscription("Bill Sikes", LocalDate.parse("2021-10-12"), Some(LocalDate.parse("2050-10-01"))))
+      verifyTimerExistsAndBeenUpdated("ConsumedAPI-IF-GetPptSubscriptionDisplay-GET")
+    }
+    "return None when IF responds with 4xx" in {
+      givenPptSubscriptionRespondsWith(PptRef("XAPPT1234567890"), 404)
+      val result = connector.getPptSubscription(PptRef("XAPPT1234567890")).futureValue
+      result shouldBe None
+    }
+
+    "throw an exception when IF responds with 5xx" in {
+      givenPptSubscriptionRespondsWith(PptRef("XAPPT1234567890"), 503)
+      assertThrows[UpstreamErrorResponse]{
+        await(connector.getPptSubscription(PptRef("XAPPT1234567890")))
+      }
+    }
+  }
+
+  "getTradingNameForNino" should {
+      "return tradingName if defined in businessData" in {
+        hasABusinessPartnerRecord(nino)
+        val result = connector.getTradingNameForNino(nino).futureValue
+        result shouldBe Some("Surname DADTN")
+      }
+    "return None when no businessData is defined" in {
+      hasBusinessPartnerRecordWithNoBusinessData(nino)
+      val result = connector.getTradingNameForNino(nino).futureValue
+      result shouldBe None
+    }
+    "return None when no tradingName is defined within businessData" in {
+      hasABusinessPartnerRecordWithBusinessDataWithNoTradingName(nino)
+      val result = connector.getTradingNameForNino(nino).futureValue
+      result shouldBe None
+    }
+
+    "return None when the Nino is not found" in {
+      hasNoBusinessPartnerRecord(nino)
+      val result = connector.getTradingNameForNino(nino).futureValue
+      result shouldBe None
+    }
+
+    "throw an exception when DES returns a 5xx response" in {
+      assertThrows[UpstreamErrorResponse]{
+        businessPartnerRecordFails(nino, 503)
+        await(connector.getTradingNameForNino(nino))
+      }
+    }
+  }
+
+  private def connector = app.injector.instanceOf[IfConnector]
+}

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/AgentServicesControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/AgentServicesControllerISpec.scala
@@ -496,7 +496,7 @@ class AgentServicesControllerISpec extends BaseISpec {
   "GET /client/mtdItId/:mtdItId" should {
     "return Ok and a valid nino in the response" in {
       isLoggedIn
-      givenNinoIsKnownFor(mtdItId, nino)
+      givenNinoForMtdItId(mtdItId, nino)
 
       val result = getClientNino(mtdItId)
       result.status shouldBe OK

--- a/it/uk/gov/hmrc/agentclientauthorisation/controllers/TerminateInvitationsISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/controllers/TerminateInvitationsISpec.scala
@@ -11,7 +11,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientauthorisation.audit.AuditService
 import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
-import uk.gov.hmrc.agentclientauthorisation.connectors.{CitizenDetailsConnector, DesConnector, EisConnector, RelationshipsConnector}
+import uk.gov.hmrc.agentclientauthorisation.connectors.{CitizenDetailsConnector, DesConnector, EisConnector, IfConnector, RelationshipsConnector}
 import uk.gov.hmrc.agentclientauthorisation.controllers.ErrorResults.{genericBadRequest, genericInternalServerError}
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentclientauthorisation.repository._
@@ -38,6 +38,7 @@ class TerminateInvitationsISpec extends BaseISpec {
   val authConnector = app.injector.instanceOf(classOf[AuthConnector])
   val postcodeService = app.injector.instanceOf(classOf[PostcodeService])
   val desConnector = app.injector.instanceOf(classOf[DesConnector])
+  val ifConnector = app.injector.instanceOf(classOf[IfConnector])
   val eisConnector = app.injector.instanceOf(classOf[EisConnector])
   val auditService = app.injector.instanceOf(classOf[AuditService])
   val knownFactsCheckService = app.injector.instanceOf(classOf[KnownFactsCheckService])
@@ -55,7 +56,7 @@ class TerminateInvitationsISpec extends BaseISpec {
     new AgentLinkService(agentReferenceRepository, desConnector, metrics)
 
   def testInvitationsService(invitationsRepository: InvitationsRepository, agentReferenceRepository: AgentReferenceRepository) =
-    new InvitationsService(invitationsRepository, relationshipConnector, analyticsService, desConnector, emailService, auditService, appConfig, metrics)
+    new InvitationsService(invitationsRepository, relationshipConnector, analyticsService, desConnector, ifConnector, emailService, auditService, appConfig, metrics)
 
   def testFailedController(invitationsRepository: InvitationsRepository, agentReferenceRepository: AgentReferenceRepository) =
     new AgencyInvitationsController(
@@ -65,6 +66,7 @@ class TerminateInvitationsISpec extends BaseISpec {
       knownFactsCheckService,
       agentLinkService(agentReferenceRepository),
       desConnector,
+      ifConnector,
       eisConnector,
       authConnector,
       citizenDetailsConnector,

--- a/it/uk/gov/hmrc/agentclientauthorisation/service/InvitationsStatusUpdateSchedulerISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/service/InvitationsStatusUpdateSchedulerISpec.scala
@@ -9,7 +9,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentclientauthorisation.audit.AuditService
 import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
-import uk.gov.hmrc.agentclientauthorisation.connectors.{DesConnector, RelationshipsConnector}
+import uk.gov.hmrc.agentclientauthorisation.connectors.{DesConnector, IfConnector, RelationshipsConnector}
 import uk.gov.hmrc.agentclientauthorisation.model.{Expired, Invitation}
 import uk.gov.hmrc.agentclientauthorisation.repository.{InvitationExpired, InvitationsRepositoryImpl, MongoScheduleRepository, ScheduleRecord}
 import uk.gov.hmrc.agentclientauthorisation.support.UnitSpec
@@ -36,6 +36,7 @@ class InvitationsStatusUpdateSchedulerISpec
   val relationshipConnector = app.injector.instanceOf[RelationshipsConnector]
   val analyticsService = app.injector.instanceOf[PlatformAnalyticsService]
   val desConnector = app.injector.instanceOf[DesConnector]
+  val ifConnector = app.injector.instanceOf[IfConnector]
   val appConfig = app.injector.instanceOf[AppConfig]
   val emailService = app.injector.instanceOf[EmailService]
   val metrics = app.injector.instanceOf[Metrics]
@@ -48,6 +49,7 @@ class InvitationsStatusUpdateSchedulerISpec
     relationshipConnector,
     analyticsService,
     desConnector,
+    ifConnector,
     emailService,
     auditService,
     appConfig,

--- a/it/uk/gov/hmrc/agentclientauthorisation/service/RoutineJobSchedulerISpec.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/service/RoutineJobSchedulerISpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.concurrent.IntegrationPatience
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientauthorisation.audit.{AgentClientInvitationEvent, AuditService}
 import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
-import uk.gov.hmrc.agentclientauthorisation.connectors.{DesConnector, RelationshipsConnector}
+import uk.gov.hmrc.agentclientauthorisation.connectors.{DesConnector, IfConnector, RelationshipsConnector}
 import uk.gov.hmrc.agentclientauthorisation.model._
 import uk.gov.hmrc.agentclientauthorisation.repository.{InvitationsRepositoryImpl, MongoScheduleRepository, RemovePersonalInfo, ScheduleRecord}
 import uk.gov.hmrc.agentclientauthorisation.support.TestConstants._
@@ -30,6 +30,7 @@ class RoutineJobSchedulerISpec extends TestKit(ActorSystem("testSystem"))
   val relationshipConnector = app.injector.instanceOf[RelationshipsConnector]
   val analyticsService = app.injector.instanceOf[PlatformAnalyticsService]
   val desConnector = app.injector.instanceOf[DesConnector]
+  val ifConnector = app.injector.instanceOf[IfConnector]
   val appConfig = app.injector.instanceOf[AppConfig]
   val emailService = app.injector.instanceOf[EmailService]
   val metrics = app.injector.instanceOf[Metrics]
@@ -42,6 +43,7 @@ class RoutineJobSchedulerISpec extends TestKit(ActorSystem("testSystem"))
     relationshipConnector,
     analyticsService,
     desConnector,
+    ifConnector,
     emailService,
     auditService,
     appConfig,

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/DesStubs.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/DesStubs.scala
@@ -134,7 +134,7 @@ trait DesStubs {
                        |  {
                        |  "safeId": "XV0000100093327",
                        |  "nino": "${nino.value}",
-                       |  "mtdbsa": "${mtdItId.value}",
+                       |  "mtdId": "${mtdItId.value}",
                        |  "propertyIncome": false,
                        |  "businessData": [
                        |    {
@@ -177,7 +177,7 @@ trait DesStubs {
                        |  {
                        |  "safeId": "XV0000100093327",
                        |  "nino": "ZR987654C",
-                       |  "mtdbsa": "${mtdItId.value}",
+                       |  "mtdId": "${mtdItId.value}",
                        |  "propertyIncome": false,
                        |  "businessData": []
                        |}
@@ -196,7 +196,7 @@ trait DesStubs {
                        |  {
                        |  "safeId": "XV0000100093327",
                        |  "nino": "ZR987654C",
-                       |  "mtdbsa": "${mtdItId.value}",
+                       |  "mtdId": "${mtdItId.value}",
                        |  "propertyIncome": false,
                        |  "propertyData": []
                        |}
@@ -321,7 +321,7 @@ trait DesStubs {
                        |                 "plrReference": "${plrId.value}",
                        |                 "upeDetails": {
                        |                     "organisationName": "OrgName",
-                       |                     "registrationDate": "${pillar2RegDate}",
+                       |                     "registrationDate": "$pillar2RegDate",
                        |                     "domesticOnly": false,
                        |                     "filingMember": false
                        |                 },
@@ -338,7 +338,7 @@ trait DesStubs {
                        |                     "emailAddress": "name@email.com"
                        |                 },
                        |                 "accountStatus": {
-                       |                     "inactive" : ${inactive}
+                       |                     "inactive" : $inactive
                        |                 }
                        |}""".stripMargin)))
     this
@@ -368,7 +368,7 @@ trait DesStubs {
 
   def getTrustName(trustTaxIdentifier: String, status: Int = 200, response: String) = {
     stubFor(
-      get(urlEqualTo(s"/trusts/agent-known-fact-check/${trustTaxIdentifier}"))
+      get(urlEqualTo(s"/trusts/agent-known-fact-check/$trustTaxIdentifier"))
         .withHeader("authorization", equalTo("Bearer secret"))
         .withHeader("environment", equalTo("test"))
         .willReturn(
@@ -535,8 +535,6 @@ trait DesStubs {
       |}
     """.stripMargin
 
-
-
   def givenDESReturnsError(
                             identifier: TaxIdentifier,
                             responseCode: Int,
@@ -551,33 +549,33 @@ trait DesStubs {
           .withBody(errorMessage)))
 
 
-  def givenNinoIsUnknownFor(mtdbsa: MtdItId) =
+  def givenNinoIsUnknownFor(mtdId: MtdItId): StubMapping =
     stubFor(
-      get(urlEqualTo(s"/registration/business-details/mtdbsa/${mtdbsa.value}"))
+      get(urlEqualTo(s"/registration/business-details/mtdId/${mtdId.value}"))
         .willReturn(aResponse().withStatus(404)))
 
-  def givenMtdItIdIsUnknownFor(nino: Nino) =
+  def givenMtdItIdIsUnknownFor(nino: Nino): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
         .willReturn(aResponse().withStatus(404)))
 
-  def givenNinoIsKnownFor(mtdbsa: MtdItId, nino: Nino) =
+  def givenNinoForMtdItId(mtdId: MtdItId, nino: Nino): StubMapping =
     stubFor(
-      get(urlEqualTo(s"/registration/business-details/mtdbsa/${mtdbsa.value}"))
+      get(urlEqualTo(s"/registration/business-details/mtdId/${mtdId.value}"))
         .willReturn(aResponse().withStatus(200).withBody(s"""{ "nino": "${nino.value}" }""")))
 
-  def givenMtdItIdIsKnownFor(nino: Nino, mtdItId: MtdItId) =
+  def givenMtdItIdIsKnownFor(nino: Nino, mtdItId: MtdItId): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
-        .willReturn(aResponse().withStatus(200).withBody(s"""{ "mtdbsa": "${mtdItId.value}" }""")))
+        .willReturn(aResponse().withStatus(200).withBody(s"""{ "mtdId": "${mtdItId.value}" }""")))
 
-  def givenTradingNameIsKnownFor(nino: Nino, tradingName: String) =
+  def givenTradingNameIsKnownFor(nino: Nino, tradingName: String): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
         .willReturn(aResponse().withStatus(200).withBody(s"""{
     "safeId" : "XE00001234567890",
     "nino" : "AA123456A",
-    "mtdbsa" : "123456789012345",
+    "mtdId" : "123456789012345",
     "propertyIncome" : false,
     "businessData" : [
         {
@@ -897,28 +895,6 @@ trait DesStubs {
                   }
                 }
               }""".stripMargin)))
-
-  def givenNinoForMtdItId(mtdItId: MtdItId, nino: Nino) =
-    stubFor(
-      get(urlEqualTo(s"/registration/business-details/mtdbsa/${mtdItId.value}"))
-        .willReturn(
-          aResponse()
-            .withStatus(200)
-            .withBody(s"""
-                         | {
-                         |    "nino":"${nino.value}"
-                         | }
-               """.stripMargin)
-        )
-    )
-  def givenNinoNotFoundForMtdItId(mtdItId: MtdItId) =
-    stubFor(
-      get(urlEqualTo(s"/registration/business-details/mtdbsa/${mtdItId.value}"))
-        .willReturn(
-          aResponse()
-            .withStatus(404)
-        )
-    )
 
   private val individualCustomerDetails =
     s"""

--- a/it/uk/gov/hmrc/agentclientauthorisation/support/DesStubs.scala
+++ b/it/uk/gov/hmrc/agentclientauthorisation/support/DesStubs.scala
@@ -34,7 +34,7 @@ trait DesStubs {
         .willReturn(aResponse()
           .withStatus(200)
           .withBody(s"""
-                       |  {
+                       |  {   "taxPayerDisplayResponse": {
                        |  "safeId": "XV0000100093327",
                        |  "nino": "ZR987654C",
                        |  "propertyIncome": false,
@@ -63,7 +63,7 @@ trait DesStubs {
                        |      "seasonal": true
                        |    }
                        |  ]
-                       |}
+                       |}}
               """.stripMargin)))
     this
   }
@@ -76,7 +76,7 @@ trait DesStubs {
         .willReturn(aResponse()
           .withStatus(200)
           .withBody(s"""
-                       |  {
+                       |  {   "taxPayerDisplayResponse":{
                        |  "safeId": "XV0000100093327",
                        |  "nino": "ZR987654C",
                        |  "propertyIncome": false,
@@ -91,7 +91,7 @@ trait DesStubs {
                        |      "seasonal": true
                        |    }
                        |  ]
-                       |}
+                       |}}
               """.stripMargin)))
     this
   }
@@ -104,7 +104,7 @@ trait DesStubs {
         .willReturn(aResponse()
           .withStatus(200)
           .withBody(s"""
-                       |  {
+                       |  {   "taxPayerDisplayResponse":{
                        |  "safeId": "XV0000100093327",
                        |  "nino": "ZR987654C",
                        |  "propertyIncome": false,
@@ -118,7 +118,7 @@ trait DesStubs {
                        |      "seasonal": true
                        |    }
                        |  ]
-                       |}
+                       |}}
               """.stripMargin)))
     this
   }
@@ -131,7 +131,7 @@ trait DesStubs {
         .willReturn(aResponse()
           .withStatus(200)
           .withBody(s"""
-                       |  {
+                       |  {   "taxPayerDisplayResponse": {
                        |  "safeId": "XV0000100093327",
                        |  "nino": "${nino.value}",
                        |  "mtdId": "${mtdItId.value}",
@@ -161,7 +161,7 @@ trait DesStubs {
                        |      "seasonal": true
                        |    }
                        |  ]
-                       |}
+                       |}}
                        |""".stripMargin)))
     this
   }
@@ -174,12 +174,13 @@ trait DesStubs {
         .willReturn(aResponse()
           .withStatus(200)
           .withBody(s"""
-                       |  {
+                       |  {  "taxPayerDisplayResponse": {
                        |  "safeId": "XV0000100093327",
                        |  "nino": "ZR987654C",
                        |  "mtdId": "${mtdItId.value}",
                        |  "propertyIncome": false,
                        |  "businessData": []
+                       |}
                        |}
                        |""".stripMargin)))
     this
@@ -192,13 +193,13 @@ trait DesStubs {
         .withHeader("environment", equalTo("test"))
         .willReturn(aResponse()
           .withStatus(200)
-          .withBody(s"""
-                       |  {
-                       |  "safeId": "XV0000100093327",
-                       |  "nino": "ZR987654C",
-                       |  "mtdId": "${mtdItId.value}",
-                       |  "propertyIncome": false,
-                       |  "propertyData": []
+          .withBody(s"""{  "taxPayerDisplayResponse": {
+                           |  "safeId": "XV0000100093327",
+                           |  "nino": "ZR987654C",
+                           |  "mtdId": "${mtdItId.value}",
+                           |  "propertyIncome": false,
+                           |  "propertyData": []
+                           |  }
                        |}
                        |""".stripMargin)))
     this
@@ -562,58 +563,65 @@ trait DesStubs {
   def givenNinoForMtdItId(mtdId: MtdItId, nino: Nino): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/mtdId/${mtdId.value}"))
-        .willReturn(aResponse().withStatus(200).withBody(s"""{ "nino": "${nino.value}" }""")))
+        .willReturn(aResponse().withStatus(200).withBody(
+          s"""{"taxPayerDisplayResponse":
+             |{ "nino": "${nino.value}" }
+             |}""".stripMargin)))
 
   def givenMtdItIdIsKnownFor(nino: Nino, mtdItId: MtdItId): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
-        .willReturn(aResponse().withStatus(200).withBody(s"""{ "mtdId": "${mtdItId.value}" }""")))
+        .willReturn(aResponse().withStatus(200).withBody(
+          s"""|{"taxPayerDisplayResponse":
+              |  {"mtdId": "${mtdItId.value}" }
+              |}""".stripMargin)))
 
   def givenTradingNameIsKnownFor(nino: Nino, tradingName: String): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
-        .willReturn(aResponse().withStatus(200).withBody(s"""{
-    "safeId" : "XE00001234567890",
-    "nino" : "AA123456A",
-    "mtdId" : "123456789012345",
-    "propertyIncome" : false,
-    "businessData" : [
-        {
-            "incomeSourceId" : "123456789012345",
-            "accountingPeriodStartDate" : "2001-01-01",
-            "accountingPeriodEndDate" : "2001-01-01",
-            "tradingName" : "$tradingName",
-            "businessAddressDetails" :
-            {
-                "addressLine1" : "100 SuttonStreet",
-                "addressLine2" : "Wokingham",
-                "addressLine3" : "Surrey",
-                "addressLine4" : "London",
-                "postalCode" : "DH14EJ",
-                "countryCode" : "GB"
-            },
-            "businessContactDetails" :
-            {
-                "phoneNumber" : "01332752856",
-                "mobileNumber" : "07782565326",
-                "faxNumber" : "01332754256",
-                "emailAddress" : "stephen@manncorpone.co.uk"
-            },
-            "tradingStartDate" : "2001-01-01",
-            "cashOrAccruals" : "cash",
-            "seasonal" : true,
-            "cessationDate" : "2001-01-01",
-            "cessationReason" : "002",
-            "paperLess" : true
-        }
-    ]
+        .willReturn(aResponse().withStatus(200).withBody(s"""{"taxPayerDisplayResponse": {
+      "safeId" : "XE00001234567890",
+      "nino" : "AA123456A",
+      "mtdId" : "123456789012345",
+      "propertyIncome" : false,
+      "businessData" : [
+          {
+              "incomeSourceId" : "123456789012345",
+              "accountingPeriodStartDate" : "2001-01-01",
+              "accountingPeriodEndDate" : "2001-01-01",
+              "tradingName" : "$tradingName",
+              "businessAddressDetails" :
+              {
+                  "addressLine1" : "100 SuttonStreet",
+                  "addressLine2" : "Wokingham",
+                  "addressLine3" : "Surrey",
+                  "addressLine4" : "London",
+                  "postalCode" : "DH14EJ",
+                  "countryCode" : "GB"
+              },
+              "businessContactDetails" :
+              {
+                  "phoneNumber" : "01332752856",
+                  "mobileNumber" : "07782565326",
+                  "faxNumber" : "01332754256",
+                  "emailAddress" : "stephen@manncorpone.co.uk"
+              },
+              "tradingStartDate" : "2001-01-01",
+              "cashOrAccruals" : "cash",
+              "seasonal" : true,
+              "cessationDate" : "2001-01-01",
+              "cessationReason" : "002",
+              "paperLess" : true
+          }
+      ]
+    }
 }
 """.stripMargin)))
 
   def givenNoTradingNameFor(nino: Nino) =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
-        .willReturn(aResponse().withStatus(200).withBody(s"""{
+        .willReturn(aResponse().withStatus(200).withBody(s"""{  "taxPayerDisplayResponse":{
     "businessData" : [
         {
             "incomeSourceId" : "123456789012345",
@@ -630,7 +638,7 @@ trait DesStubs {
             }
         }
     ]
-}
+}}
 """.stripMargin)))
 
 

--- a/test/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeadersSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeadersSpec.scala
@@ -27,6 +27,7 @@ import java.util.UUID
 class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
 
   val appConfig: AppConfig = mock[AppConfig]
+  val hc: HeaderCarrier = mock[HeaderCarrier]
   val underTest = new DesIfHeaders(appConfig)
 
   when(appConfig.ifEnvironment).thenReturn("ifEnvironment")
@@ -34,7 +35,8 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
   when(appConfig.ifAuthTokenAPI1495).thenReturn("ifAuthTokenAPI1495")
   when(appConfig.desEnvironment).thenReturn("desEnvironment")
   when(appConfig.desAuthToken).thenReturn("desAuthToken")
-
+  when(hc.sessionId).thenReturn(Option(SessionId("testSession")))
+  when(hc.requestId).thenReturn(Option(RequestId("testRequestId")))
   "outboundHeaders" when {
 
     "is DES API" when {
@@ -43,15 +45,14 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
         "contain correct headers" in {
           val viaIF = false
           val apiName = None
-          val hc: HeaderCarrier = new HeaderCarrier(sessionId = Option(SessionId("testSession")), requestId = Option(RequestId("requestId")))
 
           val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "desEnvironment")
 
           headersMap should contain("Authorization" -> "Bearer desAuthToken")
-          headersMap should contain("x-session-id"  -> "Bearer desAuthToken")
-          headersMap should contain("x-request-id"  -> "Bearer desAuthToken")
+          headersMap should contain("x-session-id"  -> "testSession")
+          headersMap should contain("x-request-id"  -> "testRequestId")
         }
       }
 
@@ -60,11 +61,13 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
           val viaIF = false
           val apiName = Some("fancyApi")
 
-          val headersMap = underTest.outboundHeaders(viaIF, apiName).toMap
+          val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "desEnvironment")
 
           headersMap should contain("Authorization" -> "Bearer desAuthToken")
+          headersMap should contain("x-session-id"  -> "testSession")
+          headersMap should contain("x-request-id"  -> "testRequestId")
         }
       }
 
@@ -73,11 +76,13 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
           val viaIF = false
           val apiName = Some("")
 
-          val headersMap = underTest.outboundHeaders(viaIF, apiName).toMap
+          val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "desEnvironment")
 
           headersMap should contain("Authorization" -> "Bearer desAuthToken")
+          headersMap should contain("x-session-id"  -> "testSession")
+          headersMap should contain("x-request-id"  -> "testRequestId")
         }
       }
     }
@@ -89,11 +94,13 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
           val viaIF = true
           val apiName = None
 
-          val headersMap = underTest.outboundHeaders(viaIF, apiName).toMap
+          val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "ifEnvironment")
 
           headersMap should not contain key("Authorization")
+          headersMap should contain("x-session-id" -> "testSession")
+          headersMap should contain("x-request-id" -> "testRequestId")
         }
       }
 
@@ -102,11 +109,13 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
           val viaIF = true
           val apiName = Some("fancyApi")
 
-          val headersMap = underTest.outboundHeaders(viaIF, apiName).toMap
+          val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "ifEnvironment")
 
           headersMap should not contain key("Authorization")
+          headersMap should contain("x-session-id" -> "testSession")
+          headersMap should contain("x-request-id" -> "testRequestId")
         }
       }
 
@@ -115,11 +124,13 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
           val viaIF = true
           val apiName = Some("getTrustName")
 
-          val headersMap = underTest.outboundHeaders(viaIF, apiName).toMap
+          val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "ifEnvironment")
 
           headersMap should contain("Authorization" -> "Bearer ifAuthTokenAPI1495")
+          headersMap should contain("x-session-id"  -> "testSession")
+          headersMap should contain("x-request-id"  -> "testRequestId")
         }
       }
 
@@ -128,11 +139,13 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
           val viaIF = true
           val apiName = Some("GetPptSubscriptionDisplay")
 
-          val headersMap = underTest.outboundHeaders(viaIF, apiName).toMap
+          val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "ifEnvironment")
 
           headersMap should contain("Authorization" -> "Bearer ifAuthTokenAPI1712")
+          headersMap should contain("x-session-id"  -> "testSession")
+          headersMap should contain("x-request-id"  -> "testRequestId")
         }
       }
     }

--- a/test/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeadersSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/connectors/DesIfHeadersSpec.scala
@@ -20,6 +20,7 @@ import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.agentclientauthorisation.config.AppConfig
 import uk.gov.hmrc.agentclientauthorisation.support.UnitSpec
+import uk.gov.hmrc.http.{HeaderCarrier, RequestId, SessionId}
 
 import java.util.UUID
 
@@ -42,12 +43,15 @@ class DesIfHeadersSpec extends UnitSpec with MockitoSugar {
         "contain correct headers" in {
           val viaIF = false
           val apiName = None
+          val hc: HeaderCarrier = new HeaderCarrier(sessionId = Option(SessionId("testSession")), requestId = Option(RequestId("requestId")))
 
-          val headersMap = underTest.outboundHeaders(viaIF, apiName).toMap
+          val headersMap = underTest.outboundHeaders(viaIF, apiName)(hc).toMap
 
           assertBaseHeaders(headersMap, "desEnvironment")
 
           headersMap should contain("Authorization" -> "Bearer desAuthToken")
+          headersMap should contain("x-session-id"  -> "Bearer desAuthToken")
+          headersMap should contain("x-request-id"  -> "Bearer desAuthToken")
         }
       }
 

--- a/test/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/controllers/AgencyInvitationsControllerSpec.scala
@@ -65,6 +65,7 @@ class AgencyInvitationsControllerSpec
   val appConfig: AppConfig = resettingMock[AppConfig]
   val mockPlayAuthConnector: PlayAuthConnector = resettingMock[PlayAuthConnector]
   override val mockDesConnector = resettingMock[DesConnector]
+  override val mockIfConnector = resettingMock[IfConnector]
   override val mockEisConnector = resettingMock[EisConnector]
   val auditConnector: AuditConnector = resettingMock[AuditConnector]
   val auditService: AuditService = new AuditService(auditConnector)
@@ -82,6 +83,7 @@ class AgencyInvitationsControllerSpec
       kfcService,
       multiInvitationsService,
       mockDesConnector,
+      mockIfConnector,
       mockEisConnector,
       mockPlayAuthConnector,
       mockCitizenDetailsConnector,

--- a/test/uk/gov/hmrc/agentclientauthorisation/service/ClientNameServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/service/ClientNameServiceSpec.scala
@@ -32,7 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ClientNameServiceSpec extends UnitSpec with MocksWithCache {
 
   val clientNameService =
-    new ClientNameService(mockCitizenDetailsConnector, mockDesConnector, mockEisConnector, agentCacheProvider)
+    new ClientNameService(mockCitizenDetailsConnector, mockDesConnector, mockIfConnector, mockEisConnector, agentCacheProvider)
 
   val nino: Nino = Nino("AB123456A")
   val mtdItId: MtdItId = MtdItId("LCLG57411010846")
@@ -57,11 +57,11 @@ class ClientNameServiceSpec extends UnitSpec with MocksWithCache {
 
   "getClientNameByService" should {
     "get the trading name if the service is ITSA" in {
-      (mockDesConnector
+      (mockIfConnector
         .getNinoFor(_: MtdItId)(_: HeaderCarrier, _: ExecutionContext))
         .expects(mtdItId, *, *)
         .returning(Future(Some(nino)))
-      (mockDesConnector
+      (mockIfConnector
         .getTradingNameForNino(_: Nino)(_: HeaderCarrier, _: ExecutionContext))
         .expects(nino, *, *)
         .returns(Future(Some("Mr Tradington")))
@@ -90,11 +90,11 @@ class ClientNameServiceSpec extends UnitSpec with MocksWithCache {
   }
   "getItsaTradingName" should {
     "get the citizen name if there is no trading name" in {
-      (mockDesConnector
+      (mockIfConnector
         .getNinoFor(_: MtdItId)(_: HeaderCarrier, _: ExecutionContext))
         .expects(mtdItId, *, *)
         .returning(Future(Some(nino)))
-      (mockDesConnector
+      (mockIfConnector
         .getTradingNameForNino(_: Nino)(_: HeaderCarrier, _: ExecutionContext))
         .expects(nino, *, *)
         .returns(Future(Some("")))
@@ -130,7 +130,7 @@ class ClientNameServiceSpec extends UnitSpec with MocksWithCache {
   "getTrustName" should {
     "get trust name from trust details when passed a utr" in {
       val trustDetailsResponse = TrustResponse(Right(TrustName("Trusted")))
-      (mockDesConnector
+      (mockIfConnector
         .getTrustName(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(utr.value, *, *)
         .returns(Future(trustDetailsResponse))
@@ -140,7 +140,7 @@ class ClientNameServiceSpec extends UnitSpec with MocksWithCache {
     }
     "get trust name from trust details when passed a urn" in {
       val trustDetailsResponse = TrustResponse(Right(TrustName("Trusted")))
-      (mockDesConnector
+      (mockIfConnector
         .getTrustName(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(urn.value, *, *)
         .returns(Future(trustDetailsResponse))

--- a/test/uk/gov/hmrc/agentclientauthorisation/support/MocksWithCache.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/support/MocksWithCache.scala
@@ -20,7 +20,7 @@ import com.kenshoo.play.metrics.Metrics
 import com.typesafe.config.Config
 import org.scalamock.scalatest.MockFactory
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.agentclientauthorisation.connectors.{CitizenDetailsConnector, DesConnector, EisConnector}
+import uk.gov.hmrc.agentclientauthorisation.connectors.{CitizenDetailsConnector, DesConnector, EisConnector, IfConnector}
 import uk.gov.hmrc.agentclientauthorisation.service.AgentCacheProvider
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -33,6 +33,7 @@ trait MocksWithCache extends MockFactory {
 
   val mockCitizenDetailsConnector: CitizenDetailsConnector = mock[CitizenDetailsConnector]
   val mockDesConnector: DesConnector = mock[DesConnector]
+  val mockIfConnector: IfConnector = mock[IfConnector]
   val mockEisConnector: EisConnector = mock[EisConnector]
 
   (mockMetrics.defaultRegistry _).expects().returns(new MetricRegistry()).anyNumberOfTimes()


### PR DESCRIPTION
When requests leaves the MDTP (e.g. requests to DES and IF), the headers are stripped from the request apart from those that are explicitly added. As of now, the only headers that are explicitly added are Authorization and Environment. 

To assist live service monitoring, we want to have the session id and request id headers available in the HoD requests so we can link.