### PR TITLE
APB-9113 use flag to get from ACR

### DIFF
--- a/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgentReferenceController.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/controllers/AgentReferenceController.scala
@@ -76,7 +76,7 @@ class AgentReferenceController @Inject() (
         result <- recordOpt match {
                     case Some(record) =>
                       invitationsService
-                        .findInvitationsInfoForClient(record.arn, clientIds, status)
+                        .findInvitationsInfoBy(record.arn, clientIds, status)
                         .map(list => Ok(Json.toJson(list)))
                     case _ => Future successful NotFound
                   }

--- a/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/Invitation.scala
@@ -194,6 +194,7 @@ object Invitation {
       i.isRelationshipEnded,
       i.relationshipEndedBy,
       i.events,
-      (i.service == Service.MtdIt && i.suppliedClientId == i.clientId) || i.status == PartialAuth
+      (i.service == Service.MtdIt && i.suppliedClientId == i.clientId) || i.status == PartialAuth,
+      i.fromAcr
     )
 }

--- a/app/uk/gov/hmrc/agentclientauthorisation/model/InvitationInfo.scala
+++ b/app/uk/gov/hmrc/agentclientauthorisation/model/InvitationInfo.scala
@@ -30,7 +30,8 @@ case class InvitationInfo(
   isRelationshipEnded: Boolean = false,
   relationshipEndedBy: Option[String] = None,
   events: List[StatusChangeEvent],
-  isAltItsa: Boolean = false
+  isAltItsa: Boolean = false,
+  fromAcr: Boolean = false
 )
 
 object InvitationInfo {

--- a/test/uk/gov/hmrc/agentclientauthorisation/controllers/AgentReferenceControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/controllers/AgentReferenceControllerSpec.scala
@@ -191,9 +191,8 @@ class AgentReferenceControllerSpec extends AkkaMaterializerSpec with ResettingMo
             .thenReturn(Future.successful(Some(agentReferenceRecord)))
 
           when(
-            mockInvitationsService.findInvitationsInfoForClient(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
-              any[HeaderCarrier],
-              any[ExecutionContext]
+            mockInvitationsService.findInvitationsInfoBy(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
+              any[HeaderCarrier]
             )
           )
             .thenReturn(Future successful List(invitationIdAndExpiryDate1, invitationIdAndExpiryDate2, invitationIdAndExpiryDate3))
@@ -221,9 +220,8 @@ class AgentReferenceControllerSpec extends AkkaMaterializerSpec with ResettingMo
         val invitations = List(invitationIdAndExpiryDate3)
 
         when(
-          mockInvitationsService.findInvitationsInfoForClient(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
-            any[HeaderCarrier],
-            any[ExecutionContext]
+          mockInvitationsService.findInvitationsInfoBy(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
+            any[HeaderCarrier]
           )
         )
           .thenReturn(Future successful invitations)
@@ -269,9 +267,8 @@ class AgentReferenceControllerSpec extends AkkaMaterializerSpec with ResettingMo
           AgentReferenceRecord("ABCDEFGH", arn, Seq("stan-lee"))
 
         when(
-          mockInvitationsService.findInvitationsInfoForClient(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
-            any[HeaderCarrier],
-            any[ExecutionContext]
+          mockInvitationsService.findInvitationsInfoBy(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
+            any[HeaderCarrier]
           )
         )
           .thenReturn(Future successful List.empty)
@@ -292,9 +289,8 @@ class AgentReferenceControllerSpec extends AkkaMaterializerSpec with ResettingMo
           AgentReferenceRecord("ABCDEFGH", arn, Seq("stan-lee"))
 
         when(
-          mockInvitationsService.findInvitationsInfoForClient(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
-            any[HeaderCarrier],
-            any[ExecutionContext]
+          mockInvitationsService.findInvitationsInfoBy(any[Arn], any[Seq[(String, String, String)]], any[Option[InvitationStatus]])(
+            any[HeaderCarrier]
           )
         )
           .thenReturn(Future successful List.empty)

--- a/test/uk/gov/hmrc/agentclientauthorisation/service/InvitationsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientauthorisation/service/InvitationsServiceSpec.scala
@@ -36,6 +36,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import uk.gov.hmrc.agentclientauthorisation.model.DetailsForEmail
 import uk.gov.hmrc.agentclientauthorisation.model.AuthorisationRequest
+import uk.gov.hmrc.agentclientauthorisation.model.Invitation.toInvitationInfo
 import uk.gov.hmrc.agentclientauthorisation.support.{ResettingMockitoSugar, TestData}
 import uk.gov.hmrc.agentmtdidentifiers.model.ClientIdentifier.ClientId
 
@@ -141,6 +142,30 @@ class InvitationsServiceSpec extends UnitSpec with ResettingMockitoSugar with Te
 
       result.length shouldBe 1
       verify(mockRelationshipsConnector, times(0)).lookupInvitations(Some(Arn("XARN1234567")), Seq(), Seq(), None)
+    }
+  }
+
+  ".findInvitationsInfoBy" should {
+    "make a call to ACR when the ACR mongo feature is enabled, and combine the ACR and ACA invitation info" in {
+      when(mockAppConfig.acrMongoActivated).thenReturn(true)
+      when(mockRelationshipsConnector.lookupInvitations(Some(Arn("XARN1234567")), Seq(Vat), Seq("123456789"), None)(hc))
+        .thenReturn(Future.successful(List(vatInvitation)))
+      when(mockInvitationsRepository.findInvitationInfoBy(Arn("XARN1234567"), Seq(("HMRC-MTD-VAT", "vrn", "123456789")), None))
+        .thenReturn(Future.successful(List(toInvitationInfo(vatInvitation.copy(fromAcr = false)))))
+      val result = await(service.findInvitationsInfoBy(Arn("XARN1234567"), Seq(("HMRC-MTD-VAT", "vrn", "123456789")), None))
+
+      result.length shouldBe 2
+      verify(mockRelationshipsConnector, times(1)).lookupInvitations(Some(Arn("XARN1234567")), Seq(Vat), Seq("123456789"), None)
+    }
+
+    "not call ACR when the ACR mongo feature is disabled, and just return ACA invitation info" in {
+      when(mockAppConfig.acrMongoActivated).thenReturn(false)
+      when(mockInvitationsRepository.findInvitationInfoBy(Arn("XARN1234567"), Seq(("HMRC-MTD-VAT", "vrn", "123456789")), None))
+        .thenReturn(Future.successful(List(toInvitationInfo(vatInvitation.copy(fromAcr = false)))))
+      val result = await(service.findInvitationsInfoBy(Arn("XARN1234567"), Seq(("HMRC-MTD-VAT", "vrn", "123456789")), None))
+
+      result.length shouldBe 1
+      verify(mockRelationshipsConnector, times(0)).lookupInvitations(Some(Arn("XARN1234567")), Seq(Vat), Seq("123456789"), None)
     }
   }
 


### PR DESCRIPTION
An update to the functionality was agreed with @geoffreywatson - the updateAltItsa side effect has been removed from this endpoint rather than wire up the same effects in ACR - it is now a pure listing method - we have agreed updates to altItsa statuses can happen on the agent's side of things as and when an agent attempts to sign up the client  